### PR TITLE
Replace command id by doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       - name: Deploy API documentation
         uses: bump-sh/github-action@0.2
         with:
-          id: <BUMP_DOC_ID>
+          doc: <BUMP_DOC_ID>
           token: <BUMP_DOC_TOKEN>
           file: doc/api-documentation.yml
 ```
@@ -33,7 +33,7 @@ Important: [actions/checkout](https://github.com/actions/checkout) has to be cal
 
 ## Inputs
 
-* `id` (required): Documentation id. Can be found in the documentation settings on https://bump.sh
+* `doc` (required): Documentation id. Can be found in the documentation settings on https://bump.sh
 
 * `token` (required): Documentation token. Can be found in the documentation settings on https://bump.sh. We recommend to use an [encrypted secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).
 


### PR DESCRIPTION
`id` has been deprecated, and replaced by `doc` with version 0.7
of `bump-cli`

cf https://github.com/bump-sh/bump-cli/commit/1fbb961922956c168dfcb9e47f93fc908254fb20