### PR TITLE
feat: send diff results to github PR comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.4.0",
-        "bump-cli": "^2.0.0"
+        "@actions/github": "^5.0.0",
+        "@octokit/types": "^6.16.4",
+        "bump-cli": "^2.1.0"
       },
       "devDependencies": {
         "@types/jest": "^26.0.15",
@@ -38,6 +40,25 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
       "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg=="
+    },
+    "node_modules/@actions/github": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
+      "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+      "dependencies": {
+        "@actions/http-client": "^1.0.11",
+        "@octokit/core": "^3.4.0",
+        "@octokit/plugin-paginate-rest": "^2.13.3",
+        "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dependencies": {
+        "tunnel": "0.0.6"
+      }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "9.0.7",
@@ -1932,6 +1953,107 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
+      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.5.tgz",
+      "integrity": "sha512-3WSAKBLa1RaR/7GG+LQR/tAZ9fp9H9waE9aPXallidyci9oZsfgsLn5M836d3LuDC6Fcym+2idRTBpssHZePVg==",
+      "dependencies": {
+        "@octokit/types": "^6.13.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
+      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+      "dependencies": {
+        "@octokit/types": "^6.16.2",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.16.4",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
+      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+      "dependencies": {
+        "@octokit/openapi-types": "^7.3.2"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -2631,6 +2753,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2709,9 +2836,9 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.0.1.tgz",
-      "integrity": "sha512-eV2+vmUsOxIbGqvzAsiq3G/VeRBD8QeXmlPOEH4SjFX77CATscO4OlalMnhPhv2ygHRkFIaAiyhx/SEzDrVIcw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.1.0.tgz",
+      "integrity": "sha512-r1n9HsCPRowAQDZBk16wwBUvGvsnspvVwRka+v3u5+VH/mZmUXBFudiZLFPeA8k+Sf9S+Yw356b4k3u5QoCBZw==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",
@@ -2722,7 +2849,7 @@
         "cli-ux": "^5.5.1",
         "debug": "^4.3.1",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
-        "tslib": "^1.14.1"
+        "tslib": "^2.3.0"
       },
       "bin": {
         "bump": "bin/run"
@@ -2730,6 +2857,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/bump-cli/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/call-me-maybe": {
       "version": "1.0.1",
@@ -3136,6 +3268,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -4397,6 +4534,14 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -7905,6 +8050,14 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7971,7 +8124,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8981,6 +9133,14 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9034,6 +9194,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -9233,8 +9398,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -9328,6 +9492,25 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
       "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg=="
+    },
+    "@actions/github": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
+      "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+      "requires": {
+        "@actions/http-client": "^1.0.11",
+        "@octokit/core": "^3.4.0",
+        "@octokit/plugin-paginate-rest": "^2.13.3",
+        "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "requires": {
+        "tunnel": "0.0.6"
+      }
     },
     "@apidevtools/json-schema-ref-parser": {
       "version": "9.0.7",
@@ -10674,6 +10857,7 @@
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "requires": {
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",
@@ -10836,6 +11020,101 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
       "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw=="
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
+      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.5.tgz",
+      "integrity": "sha512-3WSAKBLa1RaR/7GG+LQR/tAZ9fp9H9waE9aPXallidyci9oZsfgsLn5M836d3LuDC6Fcym+2idRTBpssHZePVg==",
+      "requires": {
+        "@octokit/types": "^6.13.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
+      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+      "requires": {
+        "@octokit/types": "^6.16.2",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.16.4",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
+      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+      "requires": {
+        "@octokit/openapi-types": "^7.3.2"
+      }
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -11364,6 +11643,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -11426,9 +11710,9 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.0.1.tgz",
-      "integrity": "sha512-eV2+vmUsOxIbGqvzAsiq3G/VeRBD8QeXmlPOEH4SjFX77CATscO4OlalMnhPhv2ygHRkFIaAiyhx/SEzDrVIcw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.1.0.tgz",
+      "integrity": "sha512-r1n9HsCPRowAQDZBk16wwBUvGvsnspvVwRka+v3u5+VH/mZmUXBFudiZLFPeA8k+Sf9S+Yw356b4k3u5QoCBZw==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",
@@ -11439,7 +11723,14 @@
         "cli-ux": "^5.5.1",
         "debug": "^4.3.1",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
-        "tslib": "^1.14.1"
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "call-me-maybe": {
@@ -11762,6 +12053,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -12671,6 +12967,11 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -15372,6 +15673,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -15425,7 +15731,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -16157,6 +16462,11 @@
         "tslib": "^1.8.1"
       }
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -16191,6 +16501,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
       "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -16349,8 +16664,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "clean": "rm -rf dist/",
     "format": "eslint . --ext .ts --config .eslintrc --fix",
     "format-check": "eslint . --ext .ts --config .eslintrc",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   ],
   "dependencies": {
     "@actions/core": "^1.4.0",
-    "bump-cli": "^2.0.0"
+    "@actions/github": "^5.0.0",
+    "@octokit/types": "^6.16.4",
+    "bump-cli": "^2.1.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,17 @@
+import crypto from 'crypto';
+
+const bumpDiffRegexp = /<!-- Bump.sh version_id=(.*) digest=(.*) -->/;
+
+function bumpDiffComment(versionId: string, digest: string): string {
+  return `<!-- Bump.sh version_id=${versionId} digest=${digest} -->`;
+}
+
+function extractBumpComment(body: string): string[] | null {
+  return body.match(bumpDiffRegexp);
+}
+
+function shaDigest(text: string): string {
+  return crypto.createHash('sha1').update(text, 'utf8').digest('hex');
+}
+
+export { bumpDiffComment, extractBumpComment, shaDigest };

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,43 @@
+import * as core from '@actions/core';
+import { Repo } from './github';
+import { VersionResponse } from 'bump-cli';
+import { bumpDiffComment, shaDigest } from './common';
+
+interface VersionWithDiff extends VersionResponse {
+  diff_summary: string;
+  diff_public_url: string;
+}
+
+const commentTitle = '🤖 API change detected:';
+const codeBlock = '```';
+const poweredByBump = '> _Powered by [Bump](https://bump.sh)_';
+
+export async function run(version: VersionResponse): Promise<void> {
+  if (!isVersionWithDiff(version)) {
+    core.info('No diff found, nothing more to do.');
+    return;
+  }
+
+  const repo = new Repo();
+  const digest = shaDigest(version.diff_summary);
+  const body = buildCommentBody(version, digest);
+
+  return repo.createOrUpdateComment(body, digest);
+}
+
+function isVersionWithDiff(version: VersionResponse): version is VersionWithDiff {
+  return version.diff_summary !== undefined;
+}
+
+function buildCommentBody(version: VersionWithDiff, digest: string) {
+  return [commentTitle]
+    .concat([codeBlock, version.diff_summary, codeBlock])
+    .concat([viewDiffLink(version), poweredByBump, bumpDiffComment(version.id, digest)])
+    .join('\n');
+}
+
+function viewDiffLink(version: VersionWithDiff): string {
+  return `
+[View documentation diff](${version.diff_public_url})
+`;
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,96 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
+import { GitHub } from '@actions/github/lib/utils';
+import { extractBumpComment } from './common';
+
+// These are types which are not exposed directly by Github libs
+// which we need to define
+type Octokit = InstanceType<typeof GitHub>;
+const anyOctokit = github.getOctokit('any');
+type GitHubComment = GetResponseDataTypeFromEndpointMethod<
+  typeof anyOctokit.rest.issues.createComment
+>;
+
+export class Repo {
+  readonly octokit: Octokit;
+  readonly owner: string;
+  readonly name: string;
+  readonly prNumber?: number;
+
+  constructor() {
+    // Fetch GitHub Action context
+    // from GITHUB_REPOSITORY & GITHUB_EVENT_PATH
+    const { owner, repo, number: prNumber } = github.context.issue;
+    // const { sha, ref } = github.context;
+
+    this.owner = owner;
+    this.name = repo;
+    this.prNumber = prNumber;
+
+    this.octokit = this.getOctokit();
+  }
+
+  isPr(): boolean {
+    return !!this.prNumber;
+  }
+
+  getOctokit(): Octokit {
+    const ghToken = core.getInput('github-token') || process.env['GITHUB_TOKEN'];
+
+    if (!ghToken) {
+      throw new Error(
+        'No GITHUB_TOKEN env variable available. Are you sure to run this package from a Github Action?',
+      );
+    }
+
+    return github.getOctokit(ghToken);
+  }
+
+  async createOrUpdateComment(body: string, digest: string): Promise<void> {
+    const { owner, name: repo, prNumber: issue_number, octokit } = this;
+
+    if (!issue_number) {
+      core.info('Not a pull request, nothing more to do.');
+      return;
+    }
+
+    const existingComment = await this.findExistingComment(issue_number);
+
+    if (existingComment) {
+      // We force types because of findExistingComment call which ensures
+      // body & digest exists if the comment exists but the TS compiler can't guess.
+      const [, , existingDigest] = extractBumpComment(
+        existingComment.body as string,
+      ) as string[];
+
+      if (digest !== existingDigest) {
+        await octokit.rest.issues.updateComment({
+          owner,
+          repo,
+          comment_id: existingComment.id,
+          body,
+        });
+      }
+    } else {
+      await octokit.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number,
+        body,
+      });
+    }
+  }
+
+  async findExistingComment(issue_number: number): Promise<GitHubComment | undefined> {
+    const comments = await this.octokit.rest.issues.listComments({
+      owner: this.owner,
+      repo: this.name,
+      issue_number,
+    });
+
+    return comments.data.find((comment: GitHubComment) =>
+      extractBumpComment(comment.body || ''),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 import * as core from '@actions/core';
-import BumpPreview from 'bump-cli/lib/commands/preview';
-import BumpDeploy from 'bump-cli/lib/commands/deploy';
+import * as bump from 'bump-cli';
 
 async function run(): Promise<void> {
   try {
@@ -10,10 +9,10 @@ async function run(): Promise<void> {
     const token: string = core.getInput('token');
     const command: string = core.getInput('command') || 'deploy';
     const cliParams = [file];
-    let deployCliParams = ['--doc', doc, '--token', token];
+    let docCliParams = ['--doc', doc, '--token', token];
 
     if (hub) {
-      deployCliParams = deployCliParams.concat(['--hub', hub]);
+      docCliParams = docCliParams.concat(['--hub', hub]);
     }
 
     // debug is only output if you set the secret `ACTIONS_RUNNER_DEBUG` to true
@@ -22,14 +21,20 @@ async function run(): Promise<void> {
 
     switch (command) {
       case 'preview':
-        await BumpPreview.run(cliParams);
+        await bump.Preview.run(cliParams);
         break;
       case 'dry-run':
-      case 'validate':
-        await BumpDeploy.run(cliParams.concat(deployCliParams).concat(['--dry-run']));
+      case 'validate': // DEPRECATED, kept for backward compatibility with old gem
+        await bump.Deploy.run(cliParams.concat(docCliParams).concat(['--dry-run']));
         break;
       case 'deploy':
-        await BumpDeploy.run(cliParams.concat(deployCliParams));
+        await bump.Deploy.run(cliParams.concat(docCliParams));
+        break;
+      case 'diff':
+        const changes: bump.ChangesResponse = await bump.Diff.run(
+          cliParams.concat(docCliParams),
+        );
+
         break;
     }
 

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,37 @@
+import { VersionResponse } from 'bump-cli';
+import * as diff from '../src/diff';
+
+// Mock internal github code
+import { Repo } from '../src/github';
+jest.mock('../src/github');
+const mockedInternalRepo = Repo as jest.Mocked<typeof Repo>;
+
+test('test github diff run process', async () => {
+  const version: VersionResponse = {
+    id: 'hello-123',
+    diff_summary: `one
+two
+three`,
+    diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
+  };
+  const digest = '710a99159c77e7c08094e89c1211136d2b123612';
+
+  expect(mockedInternalRepo).not.toHaveBeenCalled();
+
+  await diff.run(version);
+
+  expect(mockedInternalRepo.prototype.createOrUpdateComment).toHaveBeenCalledWith(
+    `🤖 API change detected:
+\`\`\`
+one
+two
+three
+\`\`\`
+
+[View documentation diff](https://bump.sh/doc/my-doc/changes/654)
+
+> _Powered by [Bump](https://bump.sh)_
+<!-- Bump.sh version_id=hello-123 digest=${digest} -->`,
+    digest,
+  );
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -21,40 +21,28 @@ beforeEach(() => {
 afterEach(() => stdout.stop());
 
 test('test action run deploy correctly', async () => {
-  const mockSuccessCallback = jest.fn((params) => {
-    expect(params).toContain('my-file.yml');
-    return Promise.resolve();
-  });
-  mockedDeploy.run = mockSuccessCallback;
+  expect(mockedDeploy.run).not.toHaveBeenCalled();
 
-  expect(mockSuccessCallback.mock.calls.length).toBe(0);
   process.env.INPUT_FILE = 'my-file.yml';
+  process.env.INPUT_DOC = 'my-doc';
+  process.env.INPUT_TOKEN = 'SECRET';
   await main();
-  expect(mockSuccessCallback.mock.calls.length).toBe(1);
-});
 
-test('test action runs with error', async () => {
-  const mockErrorCallback = jest.fn(() => {
-    return Promise.reject('CLI Error');
-  });
-  mockedDeploy.run = mockErrorCallback;
-
-  expect(mockErrorCallback.mock.calls.length).toBe(0);
-  process.env.INPUT_FILE = 'my-file.yml';
-  await main();
-  expect(mockErrorCallback.mock.calls.length).toBe(1);
+  expect(mockedDeploy.run).toHaveBeenCalledWith([
+    'my-file.yml',
+    '--doc',
+    'my-doc',
+    '--token',
+    'SECRET',
+  ]);
 });
 
 test('test action run preview correctly', async () => {
-  const mockSuccessCallback = jest.fn((params) => {
-    expect(params).toContain('my-file-to-preview.yml');
-    return Promise.resolve();
-  });
-  mockedPreview.run = mockSuccessCallback;
+  expect(mockedPreview.run).not.toHaveBeenCalled();
 
-  expect(mockSuccessCallback.mock.calls.length).toBe(0);
   process.env.INPUT_FILE = 'my-file-to-preview.yml';
   process.env.INPUT_COMMAND = 'preview';
   await main();
-  expect(mockSuccessCallback.mock.calls.length).toBe(1);
+
+  expect(mockedPreview.run).toHaveBeenCalledWith(['my-file-to-preview.yml']);
 });


### PR DESCRIPTION
_Needs v2.1.0 of `bump-cli` npm package. [Released ✓](https://www.npmjs.com/package/bump-cli/v/2.1.0)_

This PR adds the usage of the new `diff` command of the CLI to be able to send Documentation changes to github PR comments.

The PR is separate in three main commits:

- feat: send diff results to github PR comment
- feat: add a new 'diff' command to be able to detect doc changes
- test: simplified test cases with already mocked imports

## Demo

Here's the first test: https://github.com/bump-sh/bump/pull/758#issuecomment-871302392