### PR TITLE
diff: update GH comment when diff public URL changes

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -15,8 +15,12 @@ function extractBumpComment(body: string): string[] | null {
   return body.match(bumpDiffRegexp);
 }
 
-function shaDigest(text: string): string {
-  return crypto.createHash('sha1').update(text, 'utf8').digest('hex');
+function shaDigest(texts: string[]): string {
+  const hash = crypto.createHash('sha1');
+
+  texts.forEach((text) => hash.update(text, 'utf8'));
+
+  return hash.digest('hex');
 }
 
 export { bumpDiffComment, extractBumpComment, setUserAgent, shaDigest };

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -19,7 +19,7 @@ export async function run(version: VersionResponse): Promise<void> {
   }
 
   const repo = new Repo();
-  const digest = shaDigest(version.diff_summary);
+  const digest = shaDigest([version.diff_summary, version.diff_public_url]);
   const body = buildCommentBody(version, digest);
 
   return repo.createOrUpdateComment(body, digest);

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -1,0 +1,10 @@
+import * as common from '../src/common';
+
+test('shaDigest function', async () => {
+  const texts = ['hello'];
+  expect(common.shaDigest(texts)).toBe('aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d');
+  texts.push('world');
+  expect(common.shaDigest(texts)).toBe('6adfb183a4a2c94a2f92dab5ade762a47889a5a1');
+  texts.pop();
+  expect(common.shaDigest(texts)).toBe('aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d');
+});

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -14,7 +14,7 @@ two
 three`,
     diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
   };
-  const digest = '710a99159c77e7c08094e89c1211136d2b123612';
+  const digest = 'b62da49eb54ba0cc86e0899e3435b8ae8014dea9';
 
   expect(mockedInternalRepo).not.toHaveBeenCalled();
 


### PR DESCRIPTION
Until now we considered a Diff comment to be digested by its summary
only, however this is confusing for users because they don't see later
updates when there's no structural changes between a first diff
comment and a later commit.

With this PR we include the diff public url to be part of the
digest to make sure we update the bot GH comment when the diff
changes.

Thank you @gmourier for mentioning this issue during your tests in
https://github.com/meilisearch/specifications/pull/58! 😊