### PR TITLE
diff: update title of GH comment on breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.5.0",
         "@actions/github": "^5.0.0",
         "@octokit/types": "^6.27.0",
-        "bump-cli": "^2.1.0"
+        "bump-cli": "^2.2.1"
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
@@ -2126,6 +2126,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2391,15 +2404,16 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.1.0.tgz",
-      "integrity": "sha512-r1n9HsCPRowAQDZBk16wwBUvGvsnspvVwRka+v3u5+VH/mZmUXBFudiZLFPeA8k+Sf9S+Yw356b4k3u5QoCBZw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.1.tgz",
+      "integrity": "sha512-LAUfUcx3PzBdMQDDebYqM80MP83EtF04sy1tc6HHgjdFlMrYt6elWFuqVst2Y3zy+eIXP6hq/+YfVC7HO+0zbA==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^3.2.2",
+        "async-mutex": "^0.3.2",
         "axios": "^0.21.1",
         "cli-ux": "^5.5.1",
         "debug": "^4.3.1",
@@ -2410,7 +2424,7 @@
         "bump": "bin/run"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/bump-cli/node_modules/tslib": {
@@ -9202,6 +9216,21 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -9411,15 +9440,16 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.1.0.tgz",
-      "integrity": "sha512-r1n9HsCPRowAQDZBk16wwBUvGvsnspvVwRka+v3u5+VH/mZmUXBFudiZLFPeA8k+Sf9S+Yw356b4k3u5QoCBZw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.1.tgz",
+      "integrity": "sha512-LAUfUcx3PzBdMQDDebYqM80MP83EtF04sy1tc6HHgjdFlMrYt6elWFuqVst2Y3zy+eIXP6hq/+YfVC7HO+0zbA==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^3.2.2",
+        "async-mutex": "^0.3.2",
         "axios": "^0.21.1",
         "cli-ux": "^5.5.1",
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@actions/core": "^1.5.0",
     "@actions/github": "^5.0.0",
     "@octokit/types": "^6.27.0",
-    "bump-cli": "^2.1.0"
+    "bump-cli": "^2.2.1"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -6,11 +6,8 @@ import { bumpDiffComment, shaDigest } from './common';
 interface VersionWithDiff extends VersionResponse {
   diff_summary: string;
   diff_public_url: string;
+  diff_breaking: boolean;
 }
-
-const commentTitle = '🤖 API change detected:';
-const codeBlock = '```';
-const poweredByBump = '> _Powered by [Bump](https://bump.sh)_';
 
 export async function run(version: VersionResponse): Promise<void> {
   if (!isVersionWithDiff(version)) {
@@ -30,10 +27,20 @@ function isVersionWithDiff(version: VersionResponse): version is VersionWithDiff
 }
 
 function buildCommentBody(version: VersionWithDiff, digest: string) {
-  return [commentTitle]
+  const codeBlock = '```';
+  const poweredByBump = '> _Powered by [Bump](https://bump.sh)_';
+
+  return [title(version)]
     .concat([codeBlock, version.diff_summary, codeBlock])
     .concat([viewDiffLink(version), poweredByBump, bumpDiffComment(version.id, digest)])
     .join('\n');
+}
+
+function title(version: VersionWithDiff): string {
+  const commentTitle = '🤖 API change detected:';
+  const breakingTitle = '🚨 Breaking API change detected:';
+
+  return version.diff_breaking ? breakingTitle : commentTitle;
 }
 
 function viewDiffLink(version: VersionWithDiff): string {

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -35,3 +35,34 @@ three
     digest,
   );
 });
+
+test('test github diff with breaking changes', async () => {
+  const version: VersionResponse = {
+    id: 'hello-123',
+    diff_summary: `one
+two
+three`,
+    diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
+    diff_breaking: true,
+  };
+  const digest = 'b62da49eb54ba0cc86e0899e3435b8ae8014dea9';
+
+  expect(mockedInternalRepo).not.toHaveBeenCalled();
+
+  await diff.run(version);
+
+  expect(mockedInternalRepo.prototype.createOrUpdateComment).toHaveBeenCalledWith(
+    `🚨 Breaking API change detected:
+\`\`\`
+one
+two
+three
+\`\`\`
+
+[View documentation diff](https://bump.sh/doc/my-doc/changes/654)
+
+> _Powered by [Bump](https://bump.sh)_
+<!-- Bump.sh version_id=hello-123 digest=${digest} -->`,
+    digest,
+  );
+});


### PR DESCRIPTION
Since we now send a [more precise information](https://developers.bump.sh/changes/a71bf771-693f-49b1-95b3-756b67e9d7bf#get-versions-parameter-200-diff_breaking) about the diff in the API,
we can change the title of the Github comment to attract the users
attention on the fact the changes are *breaking*.

~_Waiting for https://github.com/bump-sh/cli/pull/155 release_~

Closes #133