### PR TITLE
Upgrade typescript from 4.3 to 4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "prettier": "^2.3.2",
         "stdout-stderr": "^0.1.13",
         "ts-jest": "^27.0.5",
-        "typescript": "^4.3.5"
+        "typescript": "^4.4.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7269,9 +7269,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13068,9 +13068,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "prettier": "^2.3.2",
     "stdout-stderr": "^0.1.13",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,8 +58,8 @@ async function run(): Promise<void> {
   }
 }
 
-function handleErrors(error: Error): void {
-  let msg = error.message;
+function handleErrors(error: unknown): void {
+  let msg = 'Unknown error';
 
   if (error instanceof GitHubHttpError) {
     msg = [
@@ -68,6 +68,8 @@ function handleErrors(error: Error): void {
       'Please check your GitHub Action workflow file or Actions repository settings.',
       'Especially if running the action on a fork PR: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/',
     ].join('\n');
+  } else if (error instanceof Error) {
+    msg = error.message;
   }
 
   core.setFailed(msg);


### PR DESCRIPTION
There's a small breaking changes on catched errors, they are now typed
as `unknown` (instead of `Error`).

Replace / closes #123