### PR TITLE
diff: use pull request base ref to perform Bump Diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.5.0",
+        "@actions/exec": "^1.1.0",
         "@actions/github": "^5.0.0",
+        "@actions/io": "^1.1.1",
         "@octokit/types": "^6.27.0",
-        "bump-cli": "^2.2.1"
+        "bump-cli": "^2.2.2"
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
@@ -41,6 +43,14 @@
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.5.0.tgz",
       "integrity": "sha512-eDOLH1Nq9zh+PJlYLqEMkS/jLQxhksPNmUGNBHfa4G+tQmnIhzpctxmchETtVGyBOvXgOVVpYuE40+eS4cUnwQ=="
     },
+    "node_modules/@actions/exec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
     "node_modules/@actions/github": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
@@ -59,6 +69,11 @@
       "dependencies": {
         "tunnel": "0.0.6"
       }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "9.0.7",
@@ -2404,9 +2419,9 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.1.tgz",
-      "integrity": "sha512-LAUfUcx3PzBdMQDDebYqM80MP83EtF04sy1tc6HHgjdFlMrYt6elWFuqVst2Y3zy+eIXP6hq/+YfVC7HO+0zbA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.2.tgz",
+      "integrity": "sha512-37OzVaoaavqh+A38GdobO0bT/ig3GM+328FNZuad1srN0cfVX5vqsCkA3RXaIXMnGja5pnVy8B0r8h9bVjce3Q==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",
@@ -7564,6 +7579,14 @@
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.5.0.tgz",
       "integrity": "sha512-eDOLH1Nq9zh+PJlYLqEMkS/jLQxhksPNmUGNBHfa4G+tQmnIhzpctxmchETtVGyBOvXgOVVpYuE40+eS4cUnwQ=="
     },
+    "@actions/exec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "requires": {
+        "@actions/io": "^1.0.1"
+      }
+    },
     "@actions/github": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
@@ -7582,6 +7605,11 @@
       "requires": {
         "tunnel": "0.0.6"
       }
+    },
+    "@actions/io": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "@apidevtools/json-schema-ref-parser": {
       "version": "9.0.7",
@@ -9440,9 +9468,9 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.1.tgz",
-      "integrity": "sha512-LAUfUcx3PzBdMQDDebYqM80MP83EtF04sy1tc6HHgjdFlMrYt6elWFuqVst2Y3zy+eIXP6hq/+YfVC7HO+0zbA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.2.tgz",
+      "integrity": "sha512-37OzVaoaavqh+A38GdobO0bT/ig3GM+328FNZuad1srN0cfVX5vqsCkA3RXaIXMnGja5pnVy8B0r8h9bVjce3Q==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
   ],
   "dependencies": {
     "@actions/core": "^1.5.0",
+    "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
+    "@actions/io": "^1.1.1",
     "@octokit/types": "^6.27.0",
-    "bump-cli": "^2.2.1"
+    "bump-cli": "^2.2.2"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import { RequestError as GitHubHttpError } from '@octokit/request-error';
 import * as bump from 'bump-cli';
 import * as diff from './diff';
+import { Repo } from './github';
 import { setUserAgent } from './common';
 
 async function run(): Promise<void> {
@@ -35,6 +36,12 @@ async function run(): Promise<void> {
         await bump.Deploy.run(cliParams.concat(docCliParams));
         break;
       case 'diff':
+        const baseFile = await new Repo().getBaseFile(file);
+
+        if (baseFile) {
+          cliParams.unshift(baseFile);
+        }
+
         await bump.Diff.run(cliParams.concat(docCliParams)).then(
           (version: bump.VersionResponse | undefined) => {
             if (version) {


### PR DESCRIPTION
~_Requirements: Bump CLI needs to be updated to support two files
input. cf https://github.com/bump-sh/cli/pull/141_~ [v2.2.2](https://github.com/bump-sh/cli/releases/tag/v2.2.2) of the CLI is released :tada:

The current 'diff' command of this action will only be able to produce
a diff with the currently deployed API definition file on
bump.sh. This is nice when you merge API changes in a single branch
one after another. However in the context of multiple parallel
changes, and with the notion of “staging” API definition file (file not yet
deployed but which is considered as the most up-to-date base), this
diff process doesn't make much sense. Why? because it will include all
changes made to the “staging” version in your own PR change.

Thus, this PR reads the PR base ref to be able to restore (from git)
the base (target) branch API definition file version. With this target
branch file version we can perform a “real” diff between the current
version file and the target branch file.