### PR TITLE
upgrade: bump-cli needs to be at least 2.2.3 for two files diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@actions/github": "^5.0.0",
         "@actions/io": "^1.1.1",
         "@octokit/types": "^6.27.0",
-        "bump-cli": "^2.2.2"
+        "bump-cli": "^2.2.3"
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
@@ -2419,9 +2419,9 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.2.tgz",
-      "integrity": "sha512-37OzVaoaavqh+A38GdobO0bT/ig3GM+328FNZuad1srN0cfVX5vqsCkA3RXaIXMnGja5pnVy8B0r8h9bVjce3Q==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.3.tgz",
+      "integrity": "sha512-Y2cvNVY2Ssk0leMxzm5+J3TKLUgLOvzRGNcESTA0ZT4teGEl6Q+h7LkQ/JNGzqInDUoRy0jwTp/ZRuFWsCH6lg==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",
@@ -9468,9 +9468,9 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.2.tgz",
-      "integrity": "sha512-37OzVaoaavqh+A38GdobO0bT/ig3GM+328FNZuad1srN0cfVX5vqsCkA3RXaIXMnGja5pnVy8B0r8h9bVjce3Q==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.3.tgz",
+      "integrity": "sha512-Y2cvNVY2Ssk0leMxzm5+J3TKLUgLOvzRGNcESTA0ZT4teGEl6Q+h7LkQ/JNGzqInDUoRy0jwTp/ZRuFWsCH6lg==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.7.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@actions/github": "^5.0.0",
     "@actions/io": "^1.1.1",
     "@octokit/types": "^6.27.0",
-    "bump-cli": "^2.2.2"
+    "bump-cli": "^2.2.3"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",


### PR DESCRIPTION
This is a necessary upgrade for the Pull request diff to work
correctly (comparing base branch with head branch).

Should have been part of #139.