### PR TITLE
deps: ugprade bump-cli to support AsyncAPI 2.1 & 2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@actions/github": "^5.0.0",
         "@actions/io": "^1.1.1",
         "@octokit/types": "^6.34.0",
-        "bump-cli": "^2.2.4"
+        "bump-cli": "^2.2.5"
       },
       "devDependencies": {
         "@types/jest": "^27.0.2",
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.7.tgz",
-      "integrity": "sha512-z8kj4GDJ640DU4msRsWprvmuC9n7vIeJW+D7Tp1xdefoLX5ZJrK7+4Xruna513wV0fSLpFzCmGz7McEP6CtKDg=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.9.0.tgz",
+      "integrity": "sha512-23/mlTzC1O4yF9RyA8QAqUlZBcsd6Fc+kktWURNgOgEam/2cbYKGrib7d7WmbfAi1NIJk9P8DqX2s7PHJ/NZsw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -2432,12 +2432,12 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.4.tgz",
-      "integrity": "sha512-9aSkZdZXfRUfHPeHNBDlg4Kg2Ntdu+FEgHcJH+twpulCDwhctdEy55NkUzMwmMkg+9k2Nh1zaE8L9iDkJRkUFA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.5.tgz",
+      "integrity": "sha512-a5v3VXJaJhltm59wvHshBG1ZqKTk1CLMVa+eUOH35K4WsqoFl3UsZ7Q5M7LE96XCYfrunx8GXMde7MW1a2NkuA==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
-        "@asyncapi/specs": "^2.7.7",
+        "@asyncapi/specs": "^2.9.0",
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^3.2.2",
@@ -7751,9 +7751,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.7.tgz",
-      "integrity": "sha512-z8kj4GDJ640DU4msRsWprvmuC9n7vIeJW+D7Tp1xdefoLX5ZJrK7+4Xruna513wV0fSLpFzCmGz7McEP6CtKDg=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.9.0.tgz",
+      "integrity": "sha512-23/mlTzC1O4yF9RyA8QAqUlZBcsd6Fc+kktWURNgOgEam/2cbYKGrib7d7WmbfAi1NIJk9P8DqX2s7PHJ/NZsw=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",
@@ -9606,12 +9606,12 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.4.tgz",
-      "integrity": "sha512-9aSkZdZXfRUfHPeHNBDlg4Kg2Ntdu+FEgHcJH+twpulCDwhctdEy55NkUzMwmMkg+9k2Nh1zaE8L9iDkJRkUFA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.2.5.tgz",
+      "integrity": "sha512-a5v3VXJaJhltm59wvHshBG1ZqKTk1CLMVa+eUOH35K4WsqoFl3UsZ7Q5M7LE96XCYfrunx8GXMde7MW1a2NkuA==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
-        "@asyncapi/specs": "^2.7.7",
+        "@asyncapi/specs": "^2.9.0",
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@actions/github": "^5.0.0",
     "@actions/io": "^1.1.1",
     "@octokit/types": "^6.34.0",
-    "bump-cli": "^2.2.4"
+    "bump-cli": "^2.2.5"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",


### PR DESCRIPTION
See release notes at https://github.com/bump-sh/cli/releases/tag/v2.2.5