### PR TITLE
diff: delete existing comment if diff is empty

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -10,12 +10,13 @@ interface VersionWithDiff extends VersionResponse {
 }
 
 export async function run(version: VersionResponse): Promise<void> {
+  const repo = new Repo();
+
   if (!isVersionWithDiff(version)) {
     core.info('No diff found, nothing more to do.');
-    return;
+    return repo.deleteExistingComment();
   }
 
-  const repo = new Repo();
   const digest = shaDigest([version.diff_summary, version.diff_public_url]);
   const body = buildCommentBody(version, digest);
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -129,4 +129,22 @@ export class Repo {
       extractBumpComment(comment.body || ''),
     );
   }
+
+  async deleteExistingComment(): Promise<void> {
+    if (!this.prNumber) {
+      core.info('Not a pull request, nothing more to do.');
+      return;
+    }
+
+    const { owner, name: repo, prNumber: issue_number, octokit } = this;
+    const existingComment = await this.findExistingComment(issue_number);
+
+    if (existingComment) {
+      await octokit.rest.issues.deleteComment({
+        owner,
+        repo,
+        comment_id: existingComment.id
+      });
+    }
+  }
 }


### PR DESCRIPTION
In case the diff result is empty, we should remove any existing Bump
comment from the PR.