### PR TITLE
diff: make sure to delete comments when no version was created

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
       - run: |
           npm install
       - run: |
+          npm run format-check
+      - run: |
           npm run all
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,30 +1,20 @@
-import * as core from '@actions/core';
 import { Repo } from './github';
 import { VersionResponse } from 'bump-cli';
 import { bumpDiffComment, shaDigest } from './common';
 
-interface VersionWithDiff extends VersionResponse {
+export interface VersionWithDiff extends VersionResponse {
   diff_summary: string;
   diff_public_url: string;
   diff_breaking: boolean;
 }
 
-export async function run(version: VersionResponse): Promise<void> {
+export async function run(version: VersionWithDiff): Promise<void> {
   const repo = new Repo();
-
-  if (!isVersionWithDiff(version)) {
-    core.info('No diff found, nothing more to do.');
-    return repo.deleteExistingComment();
-  }
 
   const digest = shaDigest([version.diff_summary, version.diff_public_url]);
   const body = buildCommentBody(version, digest);
 
   return repo.createOrUpdateComment(body, digest);
-}
-
-function isVersionWithDiff(version: VersionResponse): version is VersionWithDiff {
-  return version.diff_summary !== undefined;
 }
 
 function buildCommentBody(version: VersionWithDiff, digest: string) {

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,4 +1,3 @@
-import { VersionResponse } from 'bump-cli';
 import * as diff from '../src/diff';
 
 // Mock internal github code
@@ -7,12 +6,13 @@ jest.mock('../src/github');
 const mockedInternalRepo = Repo as jest.Mocked<typeof Repo>;
 
 test('test github diff run process', async () => {
-  const version: VersionResponse = {
+  const version: diff.VersionWithDiff = {
     id: 'hello-123',
     diff_summary: `one
 two
 three`,
     diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
+    diff_breaking: false,
   };
   const digest = 'b62da49eb54ba0cc86e0899e3435b8ae8014dea9';
 
@@ -37,7 +37,7 @@ three
 });
 
 test('test github diff with breaking changes', async () => {
-  const version: VersionResponse = {
+  const version: diff.VersionWithDiff = {
     id: 'hello-123',
     diff_summary: `one
 two

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -20,6 +20,12 @@ jest.mock('bump-cli');
 const mockedDeploy = bump.Deploy as jest.Mocked<typeof bump.Deploy>;
 const mockedDiff = bump.Diff as jest.Mocked<typeof bump.Diff>;
 const mockedPreview = bump.Preview as jest.Mocked<typeof bump.Preview>;
+const versionWithDiffExample = {
+  id: 'hello-123',
+  diff_summary: 'one',
+  diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
+  diff_breaking: true,
+};
 
 beforeEach(() => {
   stdout.stop();
@@ -76,7 +82,7 @@ test('test action run dry-run correctly', async () => {
 });
 
 test('test action run diff correctly', async () => {
-  mockedDiff.run.mockResolvedValue('cli-changes');
+  mockedDiff.run.mockResolvedValue(versionWithDiffExample);
   expect(mockedDiff.run).not.toHaveBeenCalled();
   expect(mockedInternalDiff.run).not.toHaveBeenCalled();
   expect(mockedInternalRepo).not.toHaveBeenCalled();
@@ -96,11 +102,11 @@ test('test action run diff correctly', async () => {
     '--token',
     'SECRET',
   ]);
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith('cli-changes');
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(versionWithDiffExample);
 });
 
 test('test action run diff on PR correctly', async () => {
-  mockedDiff.run.mockResolvedValue('cli-changes');
+  mockedDiff.run.mockResolvedValue(versionWithDiffExample);
   expect(mockedDiff.run).not.toHaveBeenCalled();
   expect(mockedInternalDiff.run).not.toHaveBeenCalled();
   mockedInternalRepo.prototype.getBaseFile.mockResolvedValue('my-base-file-to-diff.yml');
@@ -117,11 +123,11 @@ test('test action run diff on PR correctly', async () => {
     '--token',
     'SECRET',
   ]);
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith('cli-changes');
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(versionWithDiffExample);
 });
 
 test('test action run diff with internal exception', async () => {
-  mockedDiff.run.mockResolvedValue('cli-changes');
+  mockedDiff.run.mockResolvedValue(versionWithDiffExample);
   expect(mockedDiff.run).not.toHaveBeenCalled();
   mockedInternalDiff.run.mockRejectedValue(new Error('Boom'));
   expect(mockedInternalDiff.run).not.toHaveBeenCalled();
@@ -137,5 +143,5 @@ test('test action run diff with internal exception', async () => {
     '--token',
     'SECRET',
   ]);
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith('cli-changes');
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(versionWithDiffExample);
 });


### PR DESCRIPTION
This is a follow-up to #165 to make sure to delete an existing Github
bot comment if there is no diff.

The previous #165 only handled the cases where a non structural change
exists, the changes present in this commit is for completely empty
diffs (I.e. no changes with the currently deployed version).