### PR TITLE
diff: don't run with inexistant restored file

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import crypto from 'crypto';
 
 const bumpDiffRegexp = /<!-- Bump.sh version_id=(.*) digest=(.*) -->/;
@@ -23,4 +24,18 @@ function shaDigest(texts: string[]): string {
   return hash.digest('hex');
 }
 
-export { bumpDiffComment, extractBumpComment, setUserAgent, shaDigest };
+async function fsExists(fsPath: string): Promise<boolean> {
+  try {
+    await fs.promises.stat(fsPath);
+  } catch (err) {
+    if (err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+
+    throw err;
+  }
+
+  return true;
+}
+
+export { bumpDiffComment, extractBumpComment, fsExists, setUserAgent, shaDigest };

--- a/src/github.ts
+++ b/src/github.ts
@@ -4,7 +4,7 @@ import * as github from '@actions/github';
 import * as io from '@actions/io';
 import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 import { GitHub } from '@actions/github/lib/utils';
-import { extractBumpComment } from './common';
+import { extractBumpComment, fsExists } from './common';
 
 // These are types which are not exposed directly by Github libs
 // which we need to define
@@ -52,6 +52,7 @@ export class Repo {
 
   async getBaseFile(file: string): Promise<string | undefined> {
     const tmpDir = 'tmp/';
+    const tmpFile = `${tmpDir}${file}`;
 
     if (this.baseSha && this.headSha) {
       // Fetch base & head branch (default actions/checkout only fetches HEAD)
@@ -80,7 +81,9 @@ export class Repo {
       // & restore head branch definition in current directory
       await exec.exec('git', ['restore', '-s', this.headSha, file]);
 
-      return `${tmpDir}${file}`;
+      if (await fsExists(tmpFile)) {
+        return tmpFile;
+      }
     }
   }
 

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -8,3 +8,8 @@ test('shaDigest function', async () => {
   texts.pop();
   expect(common.shaDigest(texts)).toBe('aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d');
 });
+
+test('fsExists function', async () => {
+  expect(await common.fsExists('.')).toBe(true);
+  expect(await common.fsExists('please-don-t-make-me-fail')).toBe(false);
+});


### PR DESCRIPTION
When preparing the two files to compare with the Diff action, we need
to check if the restored file exist (in case the current PR is adding
the file, the previous base file will not exist).

If the base file doesn't exist, then don't try to add it in the
diff command paramters.