### PR TITLE
fix: make sure to restore all repository for diff command

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -67,7 +67,7 @@ export class Repo {
         },
       });
 
-      // Restore base branch definition file in a tmp directory
+      // Restore base branch version of the repository
       await io.mkdirP(tmpDir);
       await exec.exec('git', [
         '--work-tree',
@@ -75,11 +75,11 @@ export class Repo {
         'restore',
         '-s',
         commonAncestorSha,
-        file,
+        '.',
       ]);
 
-      // & restore head branch definition in current directory
-      await exec.exec('git', ['restore', '-s', this.headSha, file]);
+      // & restore head branch version in current directory
+      await exec.exec('git', ['restore', '-s', this.headSha, '.']);
 
       if (await fsExists(tmpFile)) {
         return tmpFile;

--- a/tests/fixtures/github-context.json
+++ b/tests/fixtures/github-context.json
@@ -1,0 +1,17 @@
+{
+  "repo": {
+    "owner": "bump-sh",
+    "repo": "github-action"
+  },
+  "payload": {
+    "pull_request": {
+      "number": 123,
+      "base": {
+        "sha": "6525131407398efa97db07ff60ba932c0542f0424ab"
+      },
+      "head": {
+        "sha": "4b901faf08afb49de42252a5f69dc0de694e1cfd"
+      }
+    }
+  }
+}

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,59 @@
+import { mocked } from 'ts-jest/utils';
+
+import * as github from '@actions/github';
+import * as exec from '@actions/exec';
+jest.mock('@actions/exec');
+const mockedExec = mocked(exec, true);
+
+// Shallow clone original @actions/github context
+const originalContext = { ...github.context };
+const originalGhToken = process.env['GITHUB_TOKEN'];
+
+import * as common from '../src/common';
+jest.mock('../src/common');
+const mockedCommon = common as jest.Mocked<typeof common>;
+
+import fixtureGithubContext from './fixtures/github-context.json';
+import { Repo } from '../src/github';
+
+beforeEach(() => {
+  // Mock token env variable
+  process.env['GITHUB_TOKEN'] = 'gh-12abc';
+
+  // Mock the @actions/github context.
+  Object.defineProperty(github, 'context', {
+    value: fixtureGithubContext,
+  });
+
+  mockedExec.exec.mockReset();
+});
+
+afterEach(() => {
+  // Restore original @actions/github context
+  Object.defineProperty(github, 'context', {
+    value: originalContext,
+  });
+  // Restore any original GITHUB_TOKEN env var
+  process.env['GITHUB_TOKEN'] = originalGhToken;
+});
+
+test('getBasefile function', async () => {
+  // As we don't do any git operations in tests, we mock the resulting file
+  mockedCommon.fsExists.mockResolvedValue(true);
+
+  const repo = new Repo();
+  const headFile = 'openapi.yml';
+  const baseFile = await repo.getBaseFile('openapi.yml');
+  const baseSha = fixtureGithubContext.payload.pull_request.base.sha;
+  const headSha = fixtureGithubContext.payload.pull_request.head.sha;
+  const baseBranch = '';
+
+  // Expect git executions
+  expect(mockedExec.exec.mock.calls).toEqual([
+    ['git', ['fetch', 'origin', baseSha, headSha]],
+    ['git', ['merge-base', baseSha, headSha], { listeners: expect.anything() }],
+    ['git', ['--work-tree', 'tmp/', 'restore', '-s', baseBranch, '.']],
+    ['git', ['restore', '-s', headSha, '.']],
+  ]);
+  expect(baseFile).toBe(`tmp/${headFile}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
     "declaration": true,
     "importHelpers": true,
     "module": "commonjs",


### PR DESCRIPTION
API contract files can be split out in multiple files to favor
reusability and readability. This is done thanks to the `$ref`
[references objects](https://spec.openapis.org/oas/v3.1.0#reference-object).

For our `diff` command we need to restore the previous version of the
contract file to be able to compare previous with current HEAD. The
current implementation would only restore the given root file.
With this PR we restore the entire repository in its merge-base
version. This will avoid any errors while needing to compare two API
contract files which are written with external reference objects.

Fixes #179