### PR TITLE
diff: use latest model exposed by new bump-cli version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,8 @@ inputs:
     default: api-contract.yml
   doc:
     description: 'Documentation id. Can be found in the documentation settings on https://bump.sh'
-    required: true
   token:
     description: 'Documentation token. Can be found in the documentation settings on https://bump.sh'
-    required: true
   command:
     description: 'Bump command: deploy/dry-run/preview'
     default: deploy

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@actions/io": "^1.1.1",
         "@oclif/core": "^1.0.11",
         "@octokit/types": "^6.34.0",
-        "bump-cli": "^2.3.1"
+        "bump-cli": "^2.3.2"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
@@ -2317,11 +2317,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/babel-jest": {
@@ -2573,9 +2573,9 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.1.tgz",
-      "integrity": "sha512-dQQYzvhulyancvKkDKNgsyrYOfE4ekDRYcPt7evXjgwqAsGSxQ6hRZBqggUh81oUTuWJrz/dsRGH6LrxRRblpw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.2.tgz",
+      "integrity": "sha512-kdMYd6RQyhzKJkgT4ZxmRwuSVWmojRMLAX0M0KmcLRgQw0Q1Nv7BuCNCHfyh12cKF2m4b9obkh5ANiO8/y8O4g==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.9.0",
@@ -2583,7 +2583,7 @@
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^5.1.10",
         "async-mutex": "^0.3.2",
-        "axios": "^0.24.0",
+        "axios": "^0.25.0",
         "cli-ux": "^6.0.7",
         "debug": "^4.3.1",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
@@ -3863,9 +3863,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -9722,11 +9722,11 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
       }
     },
     "babel-jest": {
@@ -9922,9 +9922,9 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.1.tgz",
-      "integrity": "sha512-dQQYzvhulyancvKkDKNgsyrYOfE4ekDRYcPt7evXjgwqAsGSxQ6hRZBqggUh81oUTuWJrz/dsRGH6LrxRRblpw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.2.tgz",
+      "integrity": "sha512-kdMYd6RQyhzKJkgT4ZxmRwuSVWmojRMLAX0M0KmcLRgQw0Q1Nv7BuCNCHfyh12cKF2m4b9obkh5ANiO8/y8O4g==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.9.0",
@@ -9932,7 +9932,7 @@
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^5.1.10",
         "async-mutex": "^0.3.2",
-        "axios": "^0.24.0",
+        "axios": "^0.25.0",
         "cli-ux": "^6.0.7",
         "debug": "^4.3.1",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
@@ -10880,9 +10880,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@actions/io": "^1.1.1",
     "@oclif/core": "^1.0.11",
     "@octokit/types": "^6.34.0",
-    "bump-cli": "^2.3.1"
+    "bump-cli": "^2.3.2"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,35 +1,35 @@
 import { Repo } from './github';
-import { WithDiff } from 'bump-cli';
+import { DiffResponse } from 'bump-cli';
 import { bumpDiffComment, shaDigest } from './common';
 
-export async function run(diff: WithDiff): Promise<void> {
+export async function run(diff: DiffResponse): Promise<void> {
   const repo = new Repo();
 
-  const digest = shaDigest([diff.diff_markdown!, diff.diff_public_url!]);
+  const digest = shaDigest([diff.markdown!, diff.public_url!]);
   const body = buildCommentBody(diff, digest);
 
   return repo.createOrUpdateComment(body, digest);
 }
 
-function buildCommentBody(diff: WithDiff, digest: string) {
+function buildCommentBody(diff: DiffResponse, digest: string) {
   const emptySpace = '';
   const poweredByBump = '> _Powered by [Bump](https://bump.sh)_';
 
   return [title(diff)]
-    .concat([emptySpace, diff.diff_markdown!])
+    .concat([emptySpace, diff.markdown!])
     .concat([viewDiffLink(diff), poweredByBump, bumpDiffComment(digest)])
     .join('\n');
 }
 
-function title(diff: WithDiff): string {
+function title(diff: DiffResponse): string {
   const commentTitle = '🤖 API change detected:';
   const breakingTitle = '🚨 Breaking API change detected:';
 
-  return diff.diff_breaking ? breakingTitle : commentTitle;
+  return diff.breaking ? breakingTitle : commentTitle;
 }
 
-function viewDiffLink(diff: WithDiff): string {
+function viewDiffLink(diff: DiffResponse): string {
   return `
-[View documentation diff](${diff.diff_public_url!})
+[View documentation diff](${diff.public_url!})
 `;
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -2,9 +2,7 @@ import { Repo } from './github';
 import { DiffResponse } from 'bump-cli';
 import { bumpDiffComment, shaDigest } from './common';
 
-export async function run(diff: DiffResponse): Promise<void> {
-  const repo = new Repo();
-
+export async function run(diff: DiffResponse, repo: Repo): Promise<void> {
   const digest = shaDigest([diff.markdown!, diff.public_url!]);
   const body = buildCommentBody(diff, digest);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,8 +53,8 @@ async function run(): Promise<void> {
 
         await new bump.Diff(config)
           .run(file1, file2, doc, hub, token)
-          .then((result: bump.WithDiff | undefined) => {
-            if (result && 'diff_markdown' in result) {
+          .then((result: bump.DiffResponse | undefined) => {
+            if (result && 'markdown' in result) {
               diff.run(result).catch(handleErrors);
             } else {
               core.info('No diff found, nothing more to do.');

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ async function run(): Promise<void> {
           .run(file1, file2, doc, hub, token)
           .then((result: bump.DiffResponse | undefined) => {
             if (result && 'markdown' in result) {
-              diff.run(result).catch(handleErrors);
+              diff.run(result, repo).catch(handleErrors);
             } else {
               core.info('No diff found, nothing more to do.');
               repo.deleteExistingComment();

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -7,13 +7,14 @@ jest.mock('../src/github');
 const mockedInternalRepo = Repo as jest.Mocked<typeof Repo>;
 
 test('test github diff run process', async () => {
-  const result: bump.WithDiff = {
-    diff_markdown: `* one
+  const result: bump.DiffResponse = {
+    id: '123abc',
+    markdown: `* one
 * two
 * three
 `,
-    diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
-    diff_breaking: false,
+    public_url: 'https://bump.sh/doc/my-doc/changes/654',
+    breaking: false,
   };
   const digest = '4b81e612cafa6580f8ad3bfe9e970b2d961f58c2';
 
@@ -38,13 +39,14 @@ test('test github diff run process', async () => {
 });
 
 test('test github diff with breaking changes', async () => {
-  const result: bump.WithDiff = {
-    diff_markdown: `* one
+  const result: bump.DiffResponse = {
+    id: '123abc',
+    markdown: `* one
 * two
 * three
 `,
-    diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
-    diff_breaking: true,
+    public_url: 'https://bump.sh/doc/my-doc/changes/654',
+    breaking: true,
   };
   const digest = '4b81e612cafa6580f8ad3bfe9e970b2d961f58c2';
 

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -20,7 +20,8 @@ test('test github diff run process', async () => {
 
   expect(mockedInternalRepo).not.toHaveBeenCalled();
 
-  await diff.run(result);
+  const repo = new Repo();
+  await diff.run(result, repo);
 
   expect(mockedInternalRepo.prototype.createOrUpdateComment).toHaveBeenCalledWith(
     `🤖 API change detected:
@@ -52,7 +53,8 @@ test('test github diff with breaking changes', async () => {
 
   expect(mockedInternalRepo).not.toHaveBeenCalled();
 
-  await diff.run(result);
+  const repo = new Repo();
+  await diff.run(result, repo);
 
   expect(mockedInternalRepo.prototype.createOrUpdateComment).toHaveBeenCalledWith(
     `🚨 Breaking API change detected:

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -19,11 +19,11 @@ jest.mock('bump-cli');
 const mockedDeploy = bump.Deploy as jest.Mocked<typeof bump.Deploy>;
 const mockedDiff = jest.mocked(bump.Diff, true);
 const mockedPreview = bump.Preview as jest.Mocked<typeof bump.Preview>;
-const versionWithDiffExample = {
+const diffExample: bump.DiffResponse = {
   id: 'hello-123',
-  diff_markdown: 'one',
-  diff_public_url: 'https://bump.sh/doc/my-doc/changes/654',
-  diff_breaking: true,
+  markdown: 'one',
+  public_url: 'https://bump.sh/doc/my-doc/changes/654',
+  breaking: true,
 };
 
 beforeEach(() => {
@@ -81,7 +81,7 @@ test('test action run dry-run correctly', async () => {
 });
 
 test('test action run diff correctly', async () => {
-  mockedDiff.prototype.run.mockResolvedValue(versionWithDiffExample);
+  mockedDiff.prototype.run.mockResolvedValue(diffExample);
   expect(mockedDiff.prototype.run).not.toHaveBeenCalled();
   expect(mockedInternalDiff.run).not.toHaveBeenCalled();
   expect(mockedInternalRepo).not.toHaveBeenCalled();
@@ -101,11 +101,11 @@ test('test action run diff correctly', async () => {
     '',
     'SECRET',
   );
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith(versionWithDiffExample);
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample);
 });
 
 test('test action run diff on PR correctly', async () => {
-  mockedDiff.prototype.run.mockResolvedValue(versionWithDiffExample);
+  mockedDiff.prototype.run.mockResolvedValue(diffExample);
   expect(mockedDiff.prototype.run).not.toHaveBeenCalled();
   expect(mockedInternalDiff.run).not.toHaveBeenCalled();
   mockedInternalRepo.prototype.getBaseFile.mockResolvedValue('my-base-file-to-diff.yml');
@@ -121,11 +121,11 @@ test('test action run diff on PR correctly', async () => {
     '',
     'SECRET',
   );
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith(versionWithDiffExample);
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample);
 });
 
 test('test action run diff with internal exception', async () => {
-  mockedDiff.prototype.run.mockResolvedValue(versionWithDiffExample);
+  mockedDiff.prototype.run.mockResolvedValue(diffExample);
   expect(mockedDiff.prototype.run).not.toHaveBeenCalled();
   mockedInternalDiff.run.mockRejectedValue(new Error('Boom'));
   expect(mockedInternalDiff.run).not.toHaveBeenCalled();
@@ -141,5 +141,5 @@ test('test action run diff with internal exception', async () => {
     '',
     'SECRET',
   );
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith(versionWithDiffExample);
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample);
 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -101,7 +101,7 @@ test('test action run diff correctly', async () => {
     '',
     'SECRET',
   );
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample);
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample, expect.any(Repo));
 });
 
 test('test action run diff on PR correctly', async () => {
@@ -121,7 +121,7 @@ test('test action run diff on PR correctly', async () => {
     '',
     'SECRET',
   );
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample);
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample, expect.any(Repo));
 });
 
 test('test action run diff with internal exception', async () => {
@@ -141,5 +141,5 @@ test('test action run diff with internal exception', async () => {
     '',
     'SECRET',
   );
-  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample);
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample, expect.any(Repo));
 });


### PR DESCRIPTION
This change is necessary to support “public diffs” (diff with no
authentication). It adapts the interface used from the `bump-cli`
package to use the new `DiffResponse` model which is the new output of
the diff library.

_Needs: new release of the CLI to support public diff (https://github.com/bump-sh/cli/pull/221)_