### PR TITLE
packages: bump the bump-cli package to support AsyncAPI 2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@actions/io": "^1.1.1",
         "@oclif/core": "^1.0.11",
         "@octokit/types": "^6.34.0",
-        "bump-cli": "^2.3.2"
+        "bump-cli": "^2.3.3"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.9.0.tgz",
-      "integrity": "sha512-23/mlTzC1O4yF9RyA8QAqUlZBcsd6Fc+kktWURNgOgEam/2cbYKGrib7d7WmbfAi1NIJk9P8DqX2s7PHJ/NZsw=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0.tgz",
+      "integrity": "sha512-X0OrxJtzwRH8iLILO/gUTDqjGVPmagmdlgdyuBggYAoGXzF6ZuAws3XCLxtPNve5eA/0V/1puwpUYEGekI22og=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -2573,12 +2573,12 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.2.tgz",
-      "integrity": "sha512-kdMYd6RQyhzKJkgT4ZxmRwuSVWmojRMLAX0M0KmcLRgQw0Q1Nv7BuCNCHfyh12cKF2m4b9obkh5ANiO8/y8O4g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.3.tgz",
+      "integrity": "sha512-il9M0WNHcEMsHg2y1Ui6Gp0ygTX4ApThfc+6MMWBD2LCoEemlU6AqudFq+eCNk/rZaZPQLnoGPA6dEWzoKAfng==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
-        "@asyncapi/specs": "^2.9.0",
+        "@asyncapi/specs": "^2.13.0",
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^5.1.10",
@@ -7961,9 +7961,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.9.0.tgz",
-      "integrity": "sha512-23/mlTzC1O4yF9RyA8QAqUlZBcsd6Fc+kktWURNgOgEam/2cbYKGrib7d7WmbfAi1NIJk9P8DqX2s7PHJ/NZsw=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0.tgz",
+      "integrity": "sha512-X0OrxJtzwRH8iLILO/gUTDqjGVPmagmdlgdyuBggYAoGXzF6ZuAws3XCLxtPNve5eA/0V/1puwpUYEGekI22og=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",
@@ -9922,12 +9922,12 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.2.tgz",
-      "integrity": "sha512-kdMYd6RQyhzKJkgT4ZxmRwuSVWmojRMLAX0M0KmcLRgQw0Q1Nv7BuCNCHfyh12cKF2m4b9obkh5ANiO8/y8O4g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.3.tgz",
+      "integrity": "sha512-il9M0WNHcEMsHg2y1Ui6Gp0ygTX4ApThfc+6MMWBD2LCoEemlU6AqudFq+eCNk/rZaZPQLnoGPA6dEWzoKAfng==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
-        "@asyncapi/specs": "^2.9.0",
+        "@asyncapi/specs": "^2.13.0",
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^5.1.10",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@actions/io": "^1.1.1",
     "@oclif/core": "^1.0.11",
     "@octokit/types": "^6.34.0",
-    "bump-cli": "^2.3.2"
+    "bump-cli": "^2.3.3"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",


### PR DESCRIPTION
What a day! (2022-02-03) to support AsyncAPI 2.3 in the Bump GitHub
Action. 😁

Check out their blog post announcement: https://www.asyncapi.com/blog/release-notes-2.3.0