### PR TITLE
core: update 'bump-cli' dependency to introduce Branch input

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ _Important: make sure to change your main destination branch name (`main` in the
 
 * `hub` (optional): Hub slug or id. Needed when deploying to a documentation attached to a Hub. Can be found in the hub settings on https://bump.sh
 
+* `branch` (optional): Branch name used during `deploy` or `diff` commands. This can be useful to maintain multiple API reference history and make it available in your API documentation.
+
 * `command`: Bump command to execute. _Default: `deploy`_
 
   * `deploy`: deploy a new version of the documentation

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,16 @@
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['js', 'ts'],
+  globals: {
+    "ts-jest": {
+         tsconfig: "tsconfig.test.json"
+    }
+  },
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
   testRunner: 'jest-circus/runner',
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
-  verbose: true
+  setupFilesAfterEnv: ['<rootDir>/tests/setup-test-env.ts'],
+  verbose: true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@actions/io": "^1.1.2",
         "@oclif/core": "^1.9.0",
         "@octokit/types": "^6.34.0",
-        "bump-cli": "^2.3.3"
+        "bump-cli": "^2.4.0"
       },
       "devDependencies": {
         "@types/jest": "^27.5.0",
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0.tgz",
-      "integrity": "sha512-X0OrxJtzwRH8iLILO/gUTDqjGVPmagmdlgdyuBggYAoGXzF6ZuAws3XCLxtPNve5eA/0V/1puwpUYEGekI22og=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-3.0.0.tgz",
+      "integrity": "sha512-Y+YfZ4u20I2BqWuoGUjOA5NJ1LKd8UTjszUz6QQm90xORP80yLgZpr5TkbtyfVLwnR556z9DGVgkMnmE+7yzVw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -1706,14 +1706,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@oclif/screen": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@octokit/auth-token": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
@@ -2375,8 +2367,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2387,11 +2378,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -2643,18 +2648,18 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.3.tgz",
-      "integrity": "sha512-il9M0WNHcEMsHg2y1Ui6Gp0ygTX4ApThfc+6MMWBD2LCoEemlU6AqudFq+eCNk/rZaZPQLnoGPA6dEWzoKAfng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.4.0.tgz",
+      "integrity": "sha512-wgHXsciVkXTtTTzeekJo+kUL61cJaTKZcQiNPsmQS3fd1tZFuo339VQgyO/b8Zmm4tACAaT9Kyk3Wvdf3OaABA==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
-        "@asyncapi/specs": "^2.13.0",
-        "@oclif/command": "^1.8.0",
+        "@asyncapi/specs": "^3.0.0",
+        "@oclif/command": "^1.8.16",
         "@oclif/config": "^1.17.0",
+        "@oclif/core": "^1.3.3",
         "@oclif/plugin-help": "^5.1.10",
         "async-mutex": "^0.3.2",
-        "axios": "^0.25.0",
-        "cli-ux": "^6.0.7",
+        "axios": "^0.27.2",
         "debug": "^4.3.1",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
         "tslib": "^2.3.0"
@@ -2663,7 +2668,7 @@
         "bump": "bin/run"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/bump-cli/node_modules/tslib": {
@@ -2787,124 +2792,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cli-ux": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-6.0.8.tgz",
-      "integrity": "sha512-ERJ61QDVS1fqnWhzp3cPFHbfucmkzWh/K6SlMlf5GweIb0wB4G/wtZiAeWK6TOTSFXGQdGczVHzWrG1BMqTmSw==",
-      "dependencies": {
-        "@oclif/core": "^1.1.1",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4 ",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.10.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cli-ux/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/cli-ux/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/cli-ux/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2957,7 +2844,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3078,7 +2964,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3683,14 +3568,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/extract-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3830,9 +3707,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "funding": [
         {
           "type": "individual",
@@ -6457,7 +6334,6 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6466,7 +6342,6 @@
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.51.0"
       },
@@ -8026,9 +7901,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0.tgz",
-      "integrity": "sha512-X0OrxJtzwRH8iLILO/gUTDqjGVPmagmdlgdyuBggYAoGXzF6ZuAws3XCLxtPNve5eA/0V/1puwpUYEGekI22og=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-3.0.0.tgz",
+      "integrity": "sha512-Y+YfZ4u20I2BqWuoGUjOA5NJ1LKd8UTjszUz6QQm90xORP80yLgZpr5TkbtyfVLwnR556z9DGVgkMnmE+7yzVw=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",
@@ -9309,11 +9184,6 @@
         "@oclif/core": "^1.0.10"
       }
     },
-    "@oclif/screen": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw=="
-    },
     "@octokit/auth-token": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
@@ -9825,8 +9695,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -9834,11 +9703,24 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "babel-jest": {
@@ -10034,18 +9916,18 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.3.3.tgz",
-      "integrity": "sha512-il9M0WNHcEMsHg2y1Ui6Gp0ygTX4ApThfc+6MMWBD2LCoEemlU6AqudFq+eCNk/rZaZPQLnoGPA6dEWzoKAfng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.4.0.tgz",
+      "integrity": "sha512-wgHXsciVkXTtTTzeekJo+kUL61cJaTKZcQiNPsmQS3fd1tZFuo339VQgyO/b8Zmm4tACAaT9Kyk3Wvdf3OaABA==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
-        "@asyncapi/specs": "^2.13.0",
-        "@oclif/command": "^1.8.0",
+        "@asyncapi/specs": "^3.0.0",
+        "@oclif/command": "^1.8.16",
         "@oclif/config": "^1.17.0",
+        "@oclif/core": "^1.3.3",
         "@oclif/plugin-help": "^5.1.10",
         "async-mutex": "^0.3.2",
-        "axios": "^0.25.0",
-        "cli-ux": "^6.0.7",
+        "axios": "^0.27.2",
         "debug": "^4.3.1",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
         "tslib": "^2.3.0"
@@ -10142,98 +10024,6 @@
         "string-width": "^4.2.0"
       }
     },
-    "cli-ux": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-6.0.8.tgz",
-      "integrity": "sha512-ERJ61QDVS1fqnWhzp3cPFHbfucmkzWh/K6SlMlf5GweIb0wB4G/wtZiAeWK6TOTSFXGQdGczVHzWrG1BMqTmSw==",
-      "requires": {
-        "@oclif/core": "^1.1.1",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4 ",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.10.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -10282,7 +10072,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -10381,8 +10170,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -10809,11 +10597,6 @@
         "jest-message-util": "^27.5.1"
       }
     },
-    "extract-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ=="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10937,9 +10720,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -12881,14 +12664,12 @@
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
       "requires": {
         "mime-db": "1.51.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@actions/io": "^1.1.2",
     "@oclif/core": "^1.9.0",
     "@octokit/types": "^6.34.0",
-    "bump-cli": "^2.3.3"
+    "bump-cli": "^2.4.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
     const file: string = core.getInput('file');
     const doc: string = core.getInput('doc');
     const hub: string = core.getInput('hub');
+    const branch: string = core.getInput('branch');
     const token: string = core.getInput('token');
     const command: string = core.getInput('command') || 'deploy';
     const cliParams = [file];
@@ -21,6 +22,10 @@ async function run(): Promise<void> {
 
     if (hub) {
       docCliParams = docCliParams.concat(['--hub', hub]);
+    }
+
+    if (branch) {
+      docCliParams = docCliParams.concat(['--branch', branch]);
     }
 
     await config.load();
@@ -52,7 +57,7 @@ async function run(): Promise<void> {
         }
 
         await new bump.Diff(config)
-          .run(file1, file2, doc, hub, token)
+          .run(file1, file2, doc, hub, branch, token, 'markdown')
           .then((result: bump.DiffResponse | undefined) => {
             if (result && 'markdown' in result) {
               diff.run(result, repo).catch(handleErrors);

--- a/tests/helpers.d.ts
+++ b/tests/helpers.d.ts
@@ -1,0 +1,3 @@
+declare namespace globalThis {
+  function mockEnv(env: Record<string, string>): () => void;
+}

--- a/tests/setup-test-env.ts
+++ b/tests/setup-test-env.ts
@@ -1,0 +1,13 @@
+global.mockEnv = (env: Record<string, string>): (() => void) => {
+  Object.keys(env).forEach((key) => {
+    process.env[key] = env[key];
+  });
+
+  const restoreCallback = () => {
+    Object.keys(env).forEach((key) => {
+      delete process.env[key];
+    });
+  };
+
+  return restoreCallback;
+};

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "files": ["./tests/helpers.d.ts"]
+}


### PR DESCRIPTION
Following the latest release of the CLI
https://github.com/bump-sh/cli/releases/tag/v2.4.0 this commit adapts
the GH action to accept a new input parameter `branch` to be able to
deploy versions to dedicated branches.