### PR TITLE
fix(diff): add “doc” related context in GH diff comments

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -5,9 +5,10 @@ function bumpDiffRegexp(docDigest: string): RegExp {
   return new RegExp(`<!-- Bump.sh.*digest=([^\\s]+)(?: doc=${docDigest})? -->`);
 }
 
-function bumpDiffComment(digest: string): string {
-  return `<!-- Bump.sh digest=${digest} -->`;
+function bumpDiffComment(docDigest: string, digest: string): string {
+  return `<!-- Bump.sh digest=${digest} doc=${docDigest} -->`;
 }
+
 // Set User-Agent for github-action
 const setUserAgent = (): void => {
   process.env.BUMP_USER_AGENT = 'bump-github-action';

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,9 @@
 import * as fs from 'fs';
 import crypto from 'crypto';
 
-const bumpDiffRegexp = /<!-- Bump.sh.*digest=(.*) -->/;
+function bumpDiffRegexp(docDigest: string): RegExp {
+  return new RegExp(`<!-- Bump.sh.*digest=([^\\s]+)(?: doc=${docDigest})? -->`);
+}
 
 function bumpDiffComment(digest: string): string {
   return `<!-- Bump.sh digest=${digest} -->`;
@@ -12,8 +14,8 @@ const setUserAgent = (): void => {
   return;
 };
 
-function extractBumpDigest(body: string): string | undefined {
-  return (body.match(bumpDiffRegexp) || []).pop();
+function extractBumpDigest(docDigest: string, body: string): string | undefined {
+  return (body.match(bumpDiffRegexp(docDigest)) || []).pop();
 }
 
 function shaDigest(texts: string[]): string {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -4,18 +4,18 @@ import { bumpDiffComment, shaDigest } from './common';
 
 export async function run(diff: DiffResponse, repo: Repo): Promise<void> {
   const digest = shaDigest([diff.markdown!, diff.public_url!]);
-  const body = buildCommentBody(diff, digest);
+  const body = buildCommentBody(repo.docDigest, diff, digest);
 
   return repo.createOrUpdateComment(body, digest);
 }
 
-function buildCommentBody(diff: DiffResponse, digest: string) {
+function buildCommentBody(docDigest: string, diff: DiffResponse, digest: string) {
   const emptySpace = '';
   const poweredByBump = '> _Powered by [Bump](https://bump.sh)_';
 
   return [title(diff)]
     .concat([emptySpace, diff.markdown!])
-    .concat([viewDiffLink(diff), poweredByBump, bumpDiffComment(digest)])
+    .concat([viewDiffLink(diff), poweredByBump, bumpDiffComment(docDigest, digest)])
     .join('\n');
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -102,12 +102,18 @@ export class Repo {
     const { owner, name: repo, prNumber: issue_number, octokit, _docDigest } = this;
     const existingComment = await this.findExistingComment(issue_number);
 
+    core.debug(`[createOrUpdatecomment] Launching for doc ${_docDigest} ...`);
+
     if (existingComment) {
       // We force types because of findExistingComment call which ensures
       // body & digest exists if the comment exists but the TS compiler can't guess.
       const existingDigest = extractBumpDigest(
         _docDigest,
         existingComment.body as string,
+      );
+
+      core.debug(
+        `[Repo#createOrUpdatecomment] Update comment (digest=${existingDigest}) for doc ${_docDigest}`,
       );
 
       if (digest !== existingDigest) {
@@ -119,6 +125,8 @@ export class Repo {
         });
       }
     } else {
+      core.debug(`[Repo#createOrUpdatecomment] Create comment for doc ${_docDigest}`);
+
       await octokit.rest.issues.createComment({
         owner,
         repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import * as bump from 'bump-cli';
 
 import * as diff from './diff';
 import { Repo } from './github';
-import { setUserAgent } from './common';
+import { setUserAgent, shaDigest } from './common';
 
 async function run(): Promise<void> {
   try {
@@ -46,7 +46,8 @@ async function run(): Promise<void> {
         await bump.Deploy.run(cliParams.concat(docCliParams));
         break;
       case 'diff':
-        const repo = new Repo();
+        const docDigest = shaDigest([doc, hub]);
+        const repo = new Repo(docDigest);
         let file1 = await repo.getBaseFile(file);
         let file2: string | undefined;
 

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -13,3 +13,40 @@ test('fsExists function', async () => {
   expect(await common.fsExists('.')).toBe(true);
   expect(await common.fsExists('please-don-t-make-me-fail')).toBe(false);
 });
+
+test('extractBumpDigest function', async () => {
+  const myDocDigest = 'ba4c368300306897504f99ec0c001f90ad35fccf';
+  const bodyDigest = 'aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d';
+  const matchingData = [
+    `
+    A long diff... with legacy signature
+
+    <!-- Bump.sh digest=${bodyDigest} -->
+    `,
+    `
+    A long diff... with new signature
+
+    <!-- Bump.sh digest=${bodyDigest} doc=ba4c368300306897504f99ec0c001f90ad35fccf -->
+    `,
+  ];
+  const nonMatchingData = [
+    `
+    A long diff... with legacy signature
+
+    <!-- NotBump digest=${bodyDigest} -->
+    `,
+    `
+    A long diff... with new signature
+
+    <!-- Bump.sh digest=${bodyDigest} doc=09d0b70e85385dee834cb060a2ef9d448df0b55d -->
+    `,
+  ];
+
+  matchingData.forEach((body) => {
+    expect(common.extractBumpDigest(myDocDigest, body)).toEqual(bodyDigest);
+  });
+
+  nonMatchingData.forEach((body) => {
+    expect(common.extractBumpDigest(myDocDigest, body)).toBeUndefined();
+  });
+});

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,8 +1,10 @@
 import * as bump from 'bump-cli';
 import * as diff from '../src/diff';
 
-// Mock internal github code
+// Mock internal Repo class
 import { Repo } from '../src/github';
+// Repo class is completely mocked (by jest.mock(...)) meaning all
+// method calls return 'undefined' (including attribute getters).
 jest.mock('../src/github');
 const mockedInternalRepo = Repo as jest.Mocked<typeof Repo>;
 
@@ -20,7 +22,7 @@ test('test github diff run process', async () => {
 
   expect(mockedInternalRepo).not.toHaveBeenCalled();
 
-  const repo = new Repo();
+  const repo = new Repo('');
   await diff.run(result, repo);
 
   expect(mockedInternalRepo.prototype.createOrUpdateComment).toHaveBeenCalledWith(
@@ -34,7 +36,7 @@ test('test github diff run process', async () => {
 [View documentation diff](https://bump.sh/doc/my-doc/changes/654)
 
 > _Powered by [Bump](https://bump.sh)_
-<!-- Bump.sh digest=${digest} -->`,
+<!-- Bump.sh digest=${digest} doc=undefined -->`,
     digest,
   );
 });
@@ -53,7 +55,7 @@ test('test github diff with breaking changes', async () => {
 
   expect(mockedInternalRepo).not.toHaveBeenCalled();
 
-  const repo = new Repo();
+  const repo = new Repo('');
   await diff.run(result, repo);
 
   expect(mockedInternalRepo.prototype.createOrUpdateComment).toHaveBeenCalledWith(
@@ -67,7 +69,7 @@ test('test github diff with breaking changes', async () => {
 [View documentation diff](https://bump.sh/doc/my-doc/changes/654)
 
 > _Powered by [Bump](https://bump.sh)_
-<!-- Bump.sh digest=${digest} -->`,
+<!-- Bump.sh digest=${digest} doc=undefined -->`,
     digest,
   );
 });

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -39,13 +39,14 @@ test('getBasefile function', async () => {
   // As we don't do any git operations in tests, we mock the resulting file
   mockedCommon.fsExists.mockResolvedValue(true);
 
-  const repo = new Repo();
+  const repo = new Repo('hello');
   const headFile = 'openapi.yml';
   const baseFile = await repo.getBaseFile('openapi.yml');
   const baseSha = fixtureGithubContext.payload.pull_request.base.sha;
   const headSha = fixtureGithubContext.payload.pull_request.head.sha;
   const baseBranch = '';
 
+  expect(repo.docDigest).toEqual('hello');
   // Expect git executions
   expect(mockedExec.exec.mock.calls).toEqual([
     ['git', ['fetch', 'origin', baseSha, headSha]],

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -129,9 +129,11 @@ test('test action run diff correctly', async () => {
     INPUT_FILE: 'my-file-to-diff.yml',
     INPUT_COMMAND: 'diff',
   });
+  const emptyDocDigest = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
 
   await main();
 
+  expect(mockedInternalRepo).toHaveBeenCalledWith(emptyDocDigest);
   expect(mockedInternalRepo.prototype.getBaseFile).toHaveBeenCalledWith(
     process.env.INPUT_FILE,
   );
@@ -142,6 +144,40 @@ test('test action run diff correctly', async () => {
     'my-file-to-diff.yml',
     undefined,
     '',
+    '',
+    '',
+    '',
+    'markdown',
+  );
+  expect(mockedInternalDiff.run).toHaveBeenCalledWith(diffExample, expect.any(Repo));
+});
+
+test('test action run diff on existing documentation correctly', async () => {
+  mockedDiff.prototype.run.mockResolvedValue(diffExample);
+  expect(mockedDiff.prototype.run).not.toHaveBeenCalled();
+  expect(mockedInternalDiff.run).not.toHaveBeenCalled();
+  expect(mockedInternalRepo).not.toHaveBeenCalled();
+
+  const restore = mockEnv({
+    INPUT_FILE: 'my-file-to-diff.yml',
+    INPUT_DOC: 'my-doc',
+    INPUT_COMMAND: 'diff',
+  });
+  const docDigest = '398b995591d7e5f6676e44f06be071abe850b38e';
+
+  await main();
+
+  expect(mockedInternalRepo).toHaveBeenCalledWith(docDigest);
+  expect(mockedInternalRepo.prototype.getBaseFile).toHaveBeenCalledWith(
+    process.env.INPUT_FILE,
+  );
+
+  restore();
+
+  expect(mockedDiff.prototype.run).toHaveBeenCalledWith(
+    'my-file-to-diff.yml',
+    undefined,
+    'my-doc',
     '',
     '',
     '',


### PR DESCRIPTION
Before this commit all comments published to GH on the diff feature
would be independent from the potential documentation/hub id (or slug)
given to the GH action inputs.

However, some of our users may want to use the GH action on multiple
different specification files (attached to different docs).

Thus with this commit we add the “context” of the documentation in the
comment signature. In this way we can remove only previous comments
for the given documentation (and avoid deleting any of the other Bump
comments)