### PR TITLE
Define permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ If you only want to have API diff summary sent as a comment on your pull request
 ```yaml
 name: API diff
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     branches:
@@ -78,6 +82,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   deploy-doc:


### PR DESCRIPTION
Since February 2nd, 2023, the default `GITHUB_TOKEN` permissions are set to read-only for every new repository.
Permissions have to be explicitly defined in workflow examples.

source: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/

cf https://github.com/bump-sh/bump/issues/3037