### PR TITLE
fix: we have made the diff public_url optional backend side

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -3,7 +3,11 @@ import { DiffResponse } from 'bump-cli';
 import { bumpDiffComment, shaDigest } from './common';
 
 export async function run(diff: DiffResponse, repo: Repo): Promise<void> {
-  const digest = shaDigest([diff.markdown!, diff.public_url!]);
+  const digestContent = [diff.markdown!];
+  if (diff.public_url) {
+    digestContent.push(diff.public_url);
+  }
+  const digest = shaDigest(digestContent);
   const body = buildCommentBody(repo.docDigest, diff, digest);
 
   return repo.createOrUpdateComment(body, digest);
@@ -27,7 +31,11 @@ function title(diff: DiffResponse): string {
 }
 
 function viewDiffLink(diff: DiffResponse): string {
-  return `
+  if (diff.public_url) {
+    return `
 [View documentation diff](${diff.public_url!})
 `;
+  } else {
+    return '';
+  }
 }

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -73,3 +73,33 @@ test('test github diff with breaking changes', async () => {
     digest,
   );
 });
+
+test('test github diff without public url', async () => {
+  const result: bump.DiffResponse = {
+    id: '123abc',
+    markdown: `* one
+* two
+* three
+`,
+    breaking: false,
+  };
+  const digest = 'c1f04e5c83235377b88745d13dc9b1ebd3a125a8';
+
+  expect(mockedInternalRepo).not.toHaveBeenCalled();
+
+  const repo = new Repo('');
+  await diff.run(result, repo);
+
+  expect(mockedInternalRepo.prototype.createOrUpdateComment).toHaveBeenCalledWith(
+    `🤖 API change detected:
+
+* one
+* two
+* three
+
+
+> _Powered by [Bump](https://bump.sh)_
+<!-- Bump.sh digest=${digest} doc=undefined -->`,
+    digest,
+  );
+});


### PR DESCRIPTION
Without this fix the diff action would fail so we need to check the
presence of the `diff.public_url` value before using it.