### PR TITLE
diff: add a `fail_on_breaking` input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ _Important: make sure to change your main destination branch name (`main` in the
 
 * `expires` (optional): Specify a longer expiration date for **public diffs** (defaults to 1 day). Use iso8601 format to provide a date, or you can use `never` to keep the result live indefinitely.
 
+* `fail_on_breaking` (optional): Mark the action as failed when a breaking change is detected with the diff command. This is only valid with `diff` command.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/bump-sh/github-action. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,13 @@ inputs:
   branch:
     description: 'Branch name used during `deploy` or `diff` commands. This can be useful to maintain multiple API reference history and make it available in your API documentation.'
   command:
-    description: 'Bump command: deploy/dry-run/preview'
+    description: 'Bump command: deploy|dry-run|preview|diff'
     default: deploy
   expires:
     description: 'Specify a longer expiration date for public diffs (defaults to 1 day). Use iso8601 format to provide a date, or you can use `never` to keep the result live indefinitely.'
+  fail_on_breaking:
+    description: 'Mark the action as failed when a breaking change is detected with the diff command. This is only valid when `diff` is provided in the command input.'
+    default: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@actions/io": "^1.1.2",
         "@oclif/core": "^1.16.4",
         "@octokit/types": "^6.34.0",
-        "bump-cli": "^2.5.0"
+        "bump-cli": "^2.6.0"
       },
       "devDependencies": {
         "@types/jest": "^27.5.0",
@@ -2765,9 +2765,9 @@
       "dev": true
     },
     "node_modules/bump-cli": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.5.0.tgz",
-      "integrity": "sha512-0Y1Dle+7++DZ628wifh6QAcJmZyqMtNWMMp5E22LoL19xaGWjHZOuuErBPRatKfZrFEHZGBZsOaChM/jnNxEcg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.6.0.tgz",
+      "integrity": "sha512-Wv0bPVvBhUaujmj3oL6c5qESAPfEbFO8vTbDko98Fu+ULWNrFNUgTtm4a2IWMHEGjNJlV7s0V+05TtbiFxfLCQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^4.0.1",
@@ -10093,9 +10093,9 @@
       "dev": true
     },
     "bump-cli": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.5.0.tgz",
-      "integrity": "sha512-0Y1Dle+7++DZ628wifh6QAcJmZyqMtNWMMp5E22LoL19xaGWjHZOuuErBPRatKfZrFEHZGBZsOaChM/jnNxEcg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.6.0.tgz",
+      "integrity": "sha512-Wv0bPVvBhUaujmj3oL6c5qESAPfEbFO8vTbDko98Fu+ULWNrFNUgTtm4a2IWMHEGjNJlV7s0V+05TtbiFxfLCQ==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@actions/io": "^1.1.2",
     "@oclif/core": "^1.16.4",
     "@octokit/types": "^6.34.0",
-    "bump-cli": "^2.5.0"
+    "bump-cli": "^2.6.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ async function run(): Promise<void> {
     const token: string = core.getInput('token');
     const command: string = core.getInput('command') || 'deploy';
     const expires: string | undefined = core.getInput('expires');
+    const failOnBreaking: boolean = core.getInput('fail_on_breaking') === 'true';
     const cliParams = [file];
     const config = new Config({ root: path.resolve(__dirname, '../') });
     let docCliParams = ['--doc', doc, '--token', token];
@@ -67,7 +68,14 @@ async function run(): Promise<void> {
               core.info('No diff found, nothing more to do.');
               repo.deleteExistingComment();
             }
-          });
+
+            if (failOnBreaking && result && !!result.breaking) {
+              throw new Error(
+                'Failing due to a breaking change detected in your API diff. Please check the diff comment on your pull request.',
+              );
+            }
+          })
+          .catch(handleErrors);
         break;
     }
 


### PR DESCRIPTION
Similarly to the recent changes on the
CLI (https://github.com/bump-sh/cli/pull/445) we introduce a new GH
action input parameter `fail_on_breaking` to allow diff command to
fail the build when there's a breaking change detected in the API diff.

---

Bonus of this PR we upgrade the CLI to the latest 2.6.0