### PR TITLE
Tiny copywriting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ _Important: make sure to change your main destination branch name (`main` in the
 
 * `token` (required): Do not add your documentation token here, but create an [encrypted secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) that holds your documentation token.
 
-  * Your Bump.sh token can be found in the documentation settings on https://bump.sh. Copy it for later usage.
+  * Your Bump.sh token can be found in the documentation settings on [your API dashboard](https://bump.sh/docs). Copy it for later usage.
   * In your GitHub repository, go to your “Settings”, and then “Secrets”.
   * Click the button “New repository secret”, name the secret `BUMP_TOKEN` and paste your Bump.sh token in the value field.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ on:
 
 jobs:
   api-diff:
-    name: Check API diff on Bump
+    name: Check API diff on Bump.sh
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
-_Important: make sure to change your main destination branch name (`main` in the example above), replace `<BUMP_DOC_ID>` with your Bump documentation slug or id and change your api specification file path (`doc/api-documentation.yml` in the example above)._
+_Important: make sure to change your main destination branch name (`main` in the example above), replace `<BUMP_DOC_ID>` with your Bump.sh documentation slug or id and change your api specification file path (`doc/api-documentation.yml` in the example above)._
 
 ### API diff on pull requests & Deploy on push
 
@@ -90,7 +90,7 @@ permissions:
 jobs:
   deploy-doc:
     if: ${{ github.event_name == 'push' }}
-    name: Deploy API documentation on Bump
+    name: Deploy API documentation on Bump.sh
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -104,7 +104,7 @@ jobs:
 
   api-diff:
     if: ${{ github.event_name == 'pull_request' }}
-    name: Check API diff on Bump
+    name: Check API diff on Bump.sh
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -120,7 +120,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
-_Important: make sure to change your main destination branch name (`main` in the example above), replace `<BUMP_DOC_ID>` with your Bump documentation slug or id and change your api specification file path (`doc/api-documentation.yml` in the example above)._
+_Important: make sure to change your main destination branch name (`main` in the example above), replace `<BUMP_DOC_ID>` with your Bump.sh documentation slug or id and change your api specification file path (`doc/api-documentation.yml` in the example above)._
 
 ### Deploy on push
 
@@ -138,7 +138,7 @@ on:
 
 jobs:
   deploy-doc:
-    name: Deploy API doc on Bump
+    name: Deploy API doc on Bump.sh
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Two commits with this PR:

- 1st, let's favor our official name Bump.sh
- 2nd, a suggestion to redirect a link to dashboard (instead of root marketing page).