### PR TITLE
deps: remove useless explicit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,8 @@
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.1.1",
         "@actions/io": "^1.1.3",
-        "@oclif/core": "^1.16.4",
         "@octokit/types": "^6.34.0",
-        "bump-cli": "^2.6.0"
+        "bump-cli": "^2.7.2"
       },
       "devDependencies": {
         "@types/jest": "^27.5.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.1.1",
     "@actions/io": "^1.1.3",
-    "@oclif/core": "^1.16.4",
     "@octokit/types": "^6.34.0",
     "bump-cli": "^2.7.2"
   },


### PR DESCRIPTION
Tiny follow-up to #454, where the package-lock file was not updated with the minimal version of the `bump-cli` package to use.

This PR also removes an unecessary explicit dependency on `@oclif/core` (which is not used by the github-action code itself).