### PR TITLE
docs: rename the GH action on marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,29 +1,30 @@
-name: 'Bump.sh'
-description: 'Keep your public, private and partner API docs in sync with your code, whether you use OpenAPI or AsyncAPI.'
+name: "Bump.sh API Documentation & Changelog"
+description: |
+  Keep your public, private and partner API docs in sync with your code, whether you use OpenAPI or AsyncAPI.
 inputs:
   file:
-    description: 'Relative path to the documentation file'
+    description: "Relative path to an API definition file (OpenAPI or AsyncAPI)"
     required: true
     default: api-contract.yml
   doc:
-    description: 'Documentation id. Can be found in the documentation settings on https://bump.sh'
+    description: "Documentation slug or id. Can be found in the documentation settings on https://bump.sh"
   token:
-    description: 'Documentation token. Can be found in the documentation settings on https://bump.sh'
+    description: "Api token. Can be found in the documentation or organization settings on https://bump.sh"
   hub:
-    description: 'Hub slug or id. Needed when deploying to a documentation attached to a Hub. Can be found in the hub settings on https://bump.sh'
+    description: "Hub slug or id. Needed when deploying to a documentation attached to a Hub. Can be found in the hub settings on https://bump.sh"
   branch:
-    description: 'Branch name used during `deploy` or `diff` commands. This can be useful to maintain multiple API reference history and make it available in your API documentation.'
+    description: "Branch name used during `deploy` or `diff` commands. This can be useful to maintain multiple API reference history and make it available in your API documentation."
   command:
-    description: 'Bump command: deploy|dry-run|preview|diff'
+    description: "Bump command: deploy|dry-run|preview|diff"
     default: deploy
   expires:
-    description: 'Specify a longer expiration date for public diffs (defaults to 1 day). Use iso8601 format to provide a date, or you can use `never` to keep the result live indefinitely.'
+    description: "Specify a longer expiration date for public diffs (defaults to 1 day). Use iso8601 format to provide a date, or you can use `never` to keep the result live indefinitely."
   fail_on_breaking:
-    description: 'Mark the action as failed when a breaking change is detected with the diff command. This is only valid when `diff` is provided in the command input.'
+    description: "Mark the action as failed when a breaking change is detected with the diff command. This is only valid when `diff` is provided in the command input."
     default: false
 runs:
-  using: 'node16'
-  main: 'dist/index.js'
+  using: "node16"
+  main: "dist/index.js"
 branding:
   color: gray-dark
   icon: book-open


### PR DESCRIPTION
This commit modifes the Action metadata to have a more meaningful name
on the GitHub marketplace (currently when searching for “API
documentation” on the marketplace doesn't show the Bump.sh action..)

Following up with https://github.com/bump-sh/docs/pull/235