### PR TITLE
feat: added overlay(s) support to deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ jobs:
 
 * `branch` (optional): Branch name used during `deploy` or `diff` commands. This can be useful to maintain multiple API reference history and make it available in your API documentation.
 
+* `overlay` (optional): Path or URL of overlay file(s) to apply before running the `deploy` command. Follows the OpenAPI Overlay specification, and accepts multiple overlays separated by comma.
+
 * `command`: Bump.sh command to execute. _Default: `deploy`_
 
   * `deploy`: deploy a new version of the documentation

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,8 @@ inputs:
   fail_on_breaking:
     description: "Mark the action as failed when a breaking change is detected with the diff command. This is only valid when `diff` is provided in the command input."
     default: false
-
+  overlay:
+    description: "A list of OpenAPI Overlays to apply to the API definition before deploying it. Overlays are applied in the order they are provided."
 runs:
   using: node20
   main: dist/index.js

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ export async function run(): Promise<void> {
     const doc: string = core.getInput('doc');
     const hub: string = core.getInput('hub');
     const branch: string = core.getInput('branch');
+    const overlay: string = core.getInput('overlay');
     const token: string = core.getInput('token');
     const command: string = core.getInput('command') || 'deploy';
     const expires: string | undefined = core.getInput('expires');
@@ -37,6 +38,10 @@ export async function run(): Promise<void> {
 
     if (branch) {
       deployParams = deployParams.concat(['--branch', branch]);
+    }
+
+    if (overlay) {
+      deployParams = deployParams.concat(processOverlays(overlay));
     }
 
     // debug is only output if you set the secret `ACTIONS_RUNNER_DEBUG` to true
@@ -112,4 +117,11 @@ function handleErrors(error: unknown): void {
 
   core.debug(JSON.stringify(error, Object.getOwnPropertyNames(error)));
   core.setFailed(msg);
+}
+
+function processOverlays(overlay: string): string[] {
+  return overlay
+    .split(',')
+    .map((o) => ['--overlay', o])
+    .flat();
 }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -123,6 +123,62 @@ describe('main.ts', () => {
       );
       expect(core.setFailed).not.toHaveBeenCalled();
     });
+
+    it('passes a single overlay correctly', async () => {
+      expect(bump.Deploy.run).not.toHaveBeenCalled();
+
+      mockInputs({
+        file: 'my-file.yml',
+        doc: 'my-doc',
+        token: 'SECRET',
+        overlay: 'overlay1.yml',
+      });
+
+      await run();
+
+      expect(bump.Deploy.run).toHaveBeenCalledWith(
+        [
+          'my-file.yml',
+          '--token',
+          'SECRET',
+          '--doc',
+          'my-doc',
+          '--overlay',
+          'overlay1.yml',
+        ],
+        '.',
+      );
+      expect(core.setFailed).not.toHaveBeenCalled();
+    });
+
+    it('passes multiple overlays correctly', async () => {
+      expect(bump.Deploy.run).not.toHaveBeenCalled();
+
+      mockInputs({
+        file: 'my-file.yml',
+        doc: 'my-doc',
+        token: 'SECRET',
+        overlay: 'overlay1.yml,overlay2.yml',
+      });
+
+      await run();
+
+      expect(bump.Deploy.run).toHaveBeenCalledWith(
+        [
+          'my-file.yml',
+          '--token',
+          'SECRET',
+          '--doc',
+          'my-doc',
+          '--overlay',
+          'overlay1.yml',
+          '--overlay',
+          'overlay2.yml',
+        ],
+        '.',
+      );
+      expect(core.setFailed).not.toHaveBeenCalled();
+    });
   });
 
   describe('preview command', () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -151,6 +151,34 @@ describe('main.ts', () => {
       expect(core.setFailed).not.toHaveBeenCalled();
     });
 
+    it('passes a single overlay with URL correctly', async () => {
+      expect(bump.Deploy.run).not.toHaveBeenCalled();
+
+      mockInputs({
+        file: 'my-file.yml',
+        doc: 'my-doc',
+        token: 'SECRET',
+        overlay:
+          'https://spec.speakeasy.com/protectearth/protectearth/train-travel-api-typescript-code-samples',
+      });
+
+      await run();
+
+      expect(bump.Deploy.run).toHaveBeenCalledWith(
+        [
+          'my-file.yml',
+          '--token',
+          'SECRET',
+          '--doc',
+          'my-doc',
+          '--overlay',
+          'https://spec.speakeasy.com/protectearth/protectearth/train-travel-api-typescript-code-samples',
+        ],
+        '.',
+      );
+      expect(core.setFailed).not.toHaveBeenCalled();
+    });
+
     it('passes multiple overlays correctly', async () => {
       expect(bump.Deploy.run).not.toHaveBeenCalled();
 


### PR DESCRIPTION
Adds support for an `overlay` input which allows an action user to provide one or more [OAI Overlays](https://github.com/OAI/Overlay-Specification).

Multiple supported by passing CSV as GitHub Actions do not yet support arrays.

Only one overlay will work until https://github.com/bump-sh/cli/pull/619 is merged. 