### PR TITLE
overlays: send input overlays to the diff core lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@actions/github": "^5.1.1",
         "@actions/io": "^1.1.3",
         "@octokit/types": "^14.1.0",
-        "bump-cli": "^2.9.3"
+        "bump-cli": "^2.9.6"
       },
       "devDependencies": {
         "@github/local-action": "^2.5.0",
@@ -5603,9 +5603,9 @@
       }
     },
     "node_modules/bump-cli": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.9.3.tgz",
-      "integrity": "sha512-bKn/4/oFUfwr2TNwOJqHwMK7Hlu8heQrh0IYl7ZLrJ3cAQAqj5Sv4lPegItxJWYN8QaMBYNZYUTvU60TGMRyeA==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/bump-cli/-/bump-cli-2.9.6.tgz",
+      "integrity": "sha512-jw1ewt2zbQ5Kmy/Oa/x1G0eodp1v4gwq3gcTzE0A+eI58gnIm7+We10SbvrmsCiYr26JMDnpGEH0VwM7eBkApw==",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@actions/github": "^5.1.1",
     "@actions/io": "^1.1.3",
     "@octokit/types": "^14.1.0",
-    "bump-cli": "^2.9.3"
+    "bump-cli": "^2.9.6"
   },
   "devDependencies": {
     "@github/local-action": "^2.5.0",

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -262,6 +262,7 @@ one
         '',
         'markdown',
         '',
+        [],
       );
     });
 
@@ -298,6 +299,7 @@ one
         '',
         'markdown',
         '',
+        [],
       );
     });
 
@@ -332,6 +334,7 @@ one
         '',
         'markdown',
         '',
+        [],
       );
     });
 
@@ -367,6 +370,7 @@ one
         '',
         'markdown',
         '',
+        [],
       );
     });
 
@@ -393,6 +397,33 @@ one
         expect.anything(),
         'markdown',
         expect.anything(),
+        [],
+      );
+    });
+
+    it('test action run with overlays', async () => {
+      const file = 'my-file-to-diff.yml';
+      mockInputs({
+        file,
+        command: 'diff',
+        fail_on_breaking: 'true',
+        overlay: 'overlay1.yml,overlay2.yml',
+      });
+      // Mock base file from PR
+      repo.mockGetBaseFile.mockResolvedValue('my-base-file-to-diff.yml');
+
+      await run();
+
+      expect(bump.mockRunDiff).toHaveBeenCalledWith(
+        'my-base-file-to-diff.yml',
+        'my-file-to-diff.yml',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'markdown',
+        expect.anything(),
+        ['overlay1.yml', 'overlay2.yml'],
       );
     });
 
@@ -432,6 +463,7 @@ one
         expect.anything(),
         'markdown',
         expect.anything(),
+        [],
       );
     });
   });


### PR DESCRIPTION
This commit adapts the `overlay` input parsing, to be able to send a
list of overlay files to the diff command if present.