### PR TITLE
deploy: allow 'filename_pattern' input

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,36 @@ jobs:
 
 **Important:** make sure you adapt the name of the branch your deployment will target, _aka_ your destination branch if relevant (`main` in the example above), replace `<BUMP_HUB_ID>` with your Bump.sh hub slug or id and point `file:` to your local API definition file folder (`docs/`).
 
+Please note, by default, only files named `{slug}-api.[format]` are deployed. Where `{slug}` is a name for your API and `[format]` is either `yaml` or `json`. Adjust to your file naming convention using the `filename_pattern:` input.
+
+Note that it _can_ include `*` wildcard special character, but **must** include the `{slug}` filter to extract your documentation’s slug from the filename. The pattern can also have any other optional fixed characters.
+
+Here’s a practical example. Let's assume that you have the following files in your `path/to/apis/` directory:
+
+```
+path/to/apis
+└─ private-api-users-service.json
+└─ partner-api-payments-service.yml
+└─ public-api-contracts-service.yml
+└─ data.json
+└─ README.md
+```
+
+In order to deploy the 3 services API definition files from this folder (`private-api-users-service.json`, `partner-api-payments-service.yml` and `public-api-contracts-service.yml`), you can set call the action like this:
+
+```
+[...]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy API documentation
+        uses: bump-sh/github-action@v1
+        with:
+          hub: <BUMP_HUB_ID>
+          token: ${{secrets.BUMP_TOKEN}}
+          file: docs/
+          filename_pattern: '*-api-{slug}-service'
+```
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: bump.sh
 
 inputs:
   file:
-    description: "Relative path to an API definition file (OpenAPI or AsyncAPI)"
+    description: "Relative path to an API definition file (OpenAPI or AsyncAPI) or a directory of definition files (when deploying to a Hub)"
     required: true
     default: api-contract.yml
   doc:
@@ -26,6 +26,9 @@ inputs:
     default: false
   overlay:
     description: "A list of OpenAPI Overlays to apply to the API definition before deploying it. Overlays are applied in the order they are provided."
+  filename_pattern:
+    default: "{slug}-api"
+    description: "Filename pattern to extract the documentation slug from filenames when deploying a DIRECTORY. Pattern uses only '*' and '{slug}' as special characters to extract the slug from a filename without extension. Only used with the 'hub' input when deploying a whole directory ."
 runs:
   using: node20
   main: dist/index.js

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ export async function run(): Promise<void> {
     const command: string = core.getInput('command') || 'deploy';
     const expires: string | undefined = core.getInput('expires');
     const failOnBreaking: boolean = core.getInput('fail_on_breaking') === 'true';
+    const filenamePattern: string = core.getInput('filename_pattern');
     const cliParams = [file];
 
     // HELP: this condition on the import meta dirname is here only
@@ -35,6 +36,12 @@ export async function run(): Promise<void> {
 
     if (hub) {
       deployParams = deployParams.concat(['--auto-create', '--hub', hub]);
+      if (filenamePattern) {
+        deployParams = deployParams.concat([
+          '--filename-pattern',
+          `'${filenamePattern}'`,
+        ]);
+      }
     }
 
     if (branch) {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -66,6 +66,32 @@ describe('main.ts', () => {
       );
     });
 
+    it('test action run deploy entire directory in hub with custom filename pattern correctly', async () => {
+      mockInputs({
+        file: 'my-file.yml',
+        doc: undefined,
+        hub: 'my-hub',
+        token: 'SECRET',
+        filename_pattern: 'source-{slug}-*',
+      });
+
+      await run();
+
+      expect(bump.Deploy.run).toHaveBeenCalledWith(
+        [
+          'my-file.yml',
+          '--token',
+          'SECRET',
+          '--auto-create',
+          '--hub',
+          'my-hub',
+          '--filename-pattern',
+          "'source-{slug}-*'",
+        ],
+        '.',
+      );
+    });
+
     it('test action run deploy correctly', async () => {
       // Set the action's inputs as return values from core.getInput().
       mockInputs({ file: 'my-file.yml', doc: 'my-doc', token: 'SECRET' });


### PR DESCRIPTION
This change adds a new input `filename_pattern:` to be able to
customize the filename pattern to deploy a set of files in a directory
to a hub.